### PR TITLE
Use latest bugfix release (v2.0.1) by default

### DIFF
--- a/build/gulpfile.js
+++ b/build/gulpfile.js
@@ -19,6 +19,7 @@ gulp.task("patch", function(cb) {
 
     jsonfile.readFile(mainTemplate, function(err, obj) {
       obj.parameters.esVersion.allowedValues = versions;
+      obj.parameters.esVersion.defaultValue = _.last(versions);
       obj.parameters.vmSizeDataNodes.allowedValues = vmSizes;
       obj.parameters.vmSizeMasterNodes.allowedValues = vmSizes;
       obj.parameters.vmSizeClientNodes.allowedValues = vmSizes;

--- a/src/mainTemplate.json
+++ b/src/mainTemplate.json
@@ -11,7 +11,7 @@
     },
     "esVersion": {
       "type": "string",
-      "defaultValue": "2.0.1",
+      "defaultValue": "2.1.0",
       "allowedValues": [
         "2.0.0",
         "2.0.1",

--- a/src/mainTemplate.json
+++ b/src/mainTemplate.json
@@ -11,7 +11,7 @@
     },
     "esVersion": {
       "type": "string",
-      "defaultValue": "2.0.0",
+      "defaultValue": "2.0.1",
       "allowedValues": [
         "2.0.0",
         "2.0.1",


### PR DESCRIPTION
Maybe we should even just use v2.1.0 instead?