### PR TITLE
Add storage account to use with Cloud Azure plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,26 @@ You may edit [build/allowedValues.json](build/allowedValues.json), which the bui
 
 Run `npm run build`, this will validate EditorConfig settings, validate JSON files, patch the allowedValues and then create a zip in the `dist` folder.
 
+### Development
+
+New features should be developed on separate branches and merged back into `master` once complete. To aid in the development process, a gulp task is configured to update all of the github template urls to point at a specific branch so that UI definition and web based deployments can be tested. To run the task
+
+```sh
+npm run links
+```
+
+will update the links to point to the name of the current branch. Once ready to merge back into `master`, a specific branch name can be passed with
+
+```sh
+npm run links -- --branch master
+```
+
 ## Marketplace
 
-The market place Elasticsearch offering offers a simplified UI over the full power of the ARM template. It will always install a cluster complete with the elasticsearch plugins Shield, Watcher & Marvel.
+The market place Elasticsearch offering offers a simplified UI over the full power of the ARM template. 
+It will always install a cluster complete with the X-Pack plugins [Shield](https://www.elastic.co/products/shield), [Watcher](https://www.elastic.co/products/watcher) and [Marvel](https://www.elastic.co/products/marvel), and for Elasticsearch 2.3.0+, [Graph](https://www.elastic.co/products/graph). 
+
+Additionally, the [Azure Cloud plugin](https://www.elastic.co/guide/en/elasticsearch/plugins/current/cloud-azure.html) is installed to support snapshot and restore.
 
 ![Example UI Flow](images/ui.gif)
 
@@ -34,24 +51,40 @@ The output from the market place UI is fed directly to the ARM template. You can
 
 <table>
   <tr><th>Parameter</td><th>Type</th><th>Description</th></tr>
-  <tr><td>esVersion</td><td>enum</td>
-    <td>A valid supported Elasticsearch version see <a href="https://github.com/elastic/azure-marketplace/blob/master/src/mainTemplate.json#L8">this list for supported versions</a>
+  <tr><td>esVersion</td><td>string</td>
+    <td>A valid supported Elasticsearch version see <a href="https://github.com/elastic/azure-marketplace/blob/master/src/mainTemplate.json#L16-L23">this list for supported versions</a>
     </td></tr>
+
   <tr><td>esClusterName</td><td>string</td>
     <td> The name of the Elasticsearch cluster
     </td></tr>
 
-  <tr><td>storageAccountName</td><td>string</td>
-    <td> The name of the storage account to use for snapshots with Cloud Azure plugin
+  <tr><td>cloudAzureStorageAccountName</td><td>string</td>
+    <td> The name of the storage account to use for snapshots with Azure Cloud plugin. 
+    Must be between 3 and 24 alphanumeric lowercase characters. Defaults to <code>essnapshot</code>.
     </td></tr>
 
-  <tr><td>storageAccountKey</td><td>securestring</td>
-    <td> The storage account key to use for the storage account with Cloud Azure plugin
+  <tr><td>cloudAzureStorageAccountExistingResourceGroup</td><td>string</td>
+    <td> The resource group name when using an existing storage account with Azure Cloud plugin.
+    <strong>Required when using an existing Storage account for Azure Cloud plugin</strong>
     </td></tr>
 
-  <tr><td>loadBalancerType</td><td>string</td>
-    <td>Whether the loadbalancer should be <code>internal</code> or <code>external</code>
-    If you run <code>external</code>, it is highly recommended to also install the shield plugin and look into setting up SSL on your endpoint. Defaults to <code>internal</code>
+  <tr><td>cloudAzureStorageAccountNewType</td><td>string</td>
+    <td> The type of storage account when creating a new storage account for Azure Cloud plugin. Defaults to <code>Standard_LRS</code>.
+    <strong>Required when using a new Storage Account for Azure Cloud plugin</strong>
+    </td></tr>
+
+  <tr><td>cloudAzureStorageAccountNewOrExisting</td><td>string</td>
+    <td> Whether to use an <code>existing</code> storage account or create a <code>new</code> storage account for Azure Cloud plugin.
+    Defaults to <code>new</code>.
+    </td></tr>
+
+  <tr><td>cloudAzureStorageAccountNewUnique</td><td>string</td>
+    <td> Whether the new storage account to use for snapshots has been validated to be unique. 
+    If set to <code>Yes</code> then the storage account name will be taken verbatim; if set to <code>No</code> then 
+    the first 11 characters of the storage account name provided in <code>cloudAzureStorageAccountName</code> 
+    will be taken as a prefix to a randomly generated unique storage account name.
+    <strong>Required when using a new Storage Account for Azure Cloud plugin</strong>
     </td></tr>
 
   <tr><td>vNetNewOrExisting</td><td>string</td>
@@ -176,7 +209,7 @@ The output from the market place UI is fed directly to the ARM template. You can
     <td>Your last name
     </td></tr>
 
-  <tr><td>userJobTitle</td><td>enum</td>
+  <tr><td>userJobTitle</td><td>string</td>
     <td>Your job title. Pick the nearest one that matches from <a href="https://github.com/elastic/azure-marketplace/blob/master/build/allowedValues.json">the list of job titles</a>
     </td></tr>
 
@@ -231,6 +264,7 @@ The above button will take you to the autogenerated web based UI based on the pa
 It should be pretty self explanatory except for password which only accepts a json object. Luckily the web UI lets you paste json in the text box. Here's an example:
 
 > {"sshPublicKey":null,"authenticationType":"password", "password":"Elastic12"}
+
 
 # License
 

--- a/build/allowedValues.json
+++ b/build/allowedValues.json
@@ -31,7 +31,7 @@
     "centralus",
     "eastus",
     "eastus2",
-    "westus",
+    "westus", 
     "northcentralus",
     "southcentralus",
     "northeurope",
@@ -45,7 +45,11 @@
     "centralindia",
     "westindia",
     "canadacentral",
-    "canadaeast"
+    "canadaeast",
+    "uksouth",
+    "ukwest",
+    "westcentralus",
+    "westus2"
   ],
   "numberOfDataNodes" : 50,
   "numberOfClientNodes" : 20,

--- a/build/arm-tests/120d-3m-30c-ext-kp.json
+++ b/build/arm-tests/120d-3m-30c-ext-kp.json
@@ -26,6 +26,7 @@
 		"userEmail": { "value": "" },
 		"userFirstName": { "value": "" },	
 		"userLastName": { "value": "" },
-		"userJobTitle": { "value": "Other" }	
+		"userJobTitle": { "value": "Other" },
+		"userCountry": { "value": "" }	
 	}
 }

--- a/build/arm-tests/3000d-0m-0c-ext-kp.json
+++ b/build/arm-tests/3000d-0m-0c-ext-kp.json
@@ -27,6 +27,7 @@
 		"userEmail": { "value": "" },
 		"userFirstName": { "value": "" },	
 		"userLastName": { "value": "" },
-		"userJobTitle": { "value": "Other" }		
+		"userJobTitle": { "value": "Other" },
+		"userCountry": { "value": "" }		
 	}
 }

--- a/build/arm-tests/3d-0m-0c-ext-kp.json
+++ b/build/arm-tests/3d-0m-0c-ext-kp.json
@@ -26,6 +26,7 @@
 		"userEmail": { "value": "" },
 		"userFirstName": { "value": "" },	
 		"userLastName": { "value": "" },
-		"userJobTitle": { "value": "Other" }	
+		"userJobTitle": { "value": "Other" },
+		"userCountry": { "value": "" }	
 	}
 }

--- a/build/arm-tests/3d-0m-0c-ext-ks.json
+++ b/build/arm-tests/3d-0m-0c-ext-ks.json
@@ -26,6 +26,7 @@
 		"userEmail": { "value": "" },
 		"userFirstName": { "value": "" },	
 		"userLastName": { "value": "" },
-		"userJobTitle": { "value": "Other" }	
+		"userJobTitle": { "value": "Other" },
+		"userCountry": { "value": "" }	
 	}
 }

--- a/build/arm-tests/3d-0m-3c-ext-kp-location.json
+++ b/build/arm-tests/3d-0m-3c-ext-kp-location.json
@@ -27,6 +27,7 @@
 		"userEmail": { "value": "" },
 		"userFirstName": { "value": "" },	
 		"userLastName": { "value": "" },
-		"userJobTitle": { "value": "Other" }	
+		"userJobTitle": { "value": "Other" },
+		"userCountry": { "value": "" }	
 	}
 }

--- a/build/arm-tests/3d-3m-3c-int-jp.json
+++ b/build/arm-tests/3d-3m-3c-int-jp.json
@@ -26,6 +26,7 @@
 		"userEmail": { "value": "" },
 		"userFirstName": { "value": "" },	
 		"userLastName": { "value": "" },
-		"userJobTitle": { "value": "Other" }	
+		"userJobTitle": { "value": "Other" },
+		"userCountry": { "value": "" }	
 	}
 }

--- a/build/arm-tests/50d-0m-0c-ext-kp0.json
+++ b/build/arm-tests/50d-0m-0c-ext-kp0.json
@@ -26,6 +26,7 @@
 		"userEmail": { "value": "" },
 		"userFirstName": { "value": "" },	
 		"userLastName": { "value": "" },
-		"userJobTitle": { "value": "Other" }	
+		"userJobTitle": { "value": "Other" },
+		"userCountry": { "value": "" }	
 	}
 }

--- a/build/tasks/patch-values.js
+++ b/build/tasks/patch-values.js
@@ -2,6 +2,9 @@ var gulp = require("gulp");
 var jsonfile = require('jsonfile');
 var _ = require('lodash');
 var replace = require('gulp-replace');
+var fs = require('fs');
+var git = require('git-rev');
+var argv = require('yargs').argv;
 
 jsonfile.spaces = 2;
 
@@ -125,5 +128,54 @@ gulp.task("patch", function(cb) {
         });
       });
     });
+  });
+});
+
+gulp.task("links", (cb) => {
+  function readFiles(dirname, branch, onFileContent, onError) {
+    fs.readdir(dirname, (err, filenames) => {
+      if (err) {
+        onError(err);
+        return;
+      }
+      filenames.forEach((filename) => {
+        if (fs.statSync(dirname + '/' + filename).isDirectory()) {
+          readFiles(dirname + '/' + filename + '/', branch, onFileContent, onError);
+        }   
+        else {
+          if (filename.endsWith('.json') || filename.endsWith('.md')) {
+            fs.readFile(dirname + filename, 'utf-8', function(err, content) {
+              if (err) {
+                onError(err);
+                return;
+              }
+              onFileContent(dirname + filename, content, branch);
+            });
+          }         
+        }
+      });
+    });
+  }
+
+  function error(err) {}
+
+  function replaceLinks(fileName, content, branch) {      
+    var link = /https:\/\/raw\.githubusercontent\.com\/elastic\/azure\-marketplace\/[a-z\-]+\/src/g;
+    var escapedLink = /https%3A%2F%2Fraw\.githubusercontent\.com%2Felastic%2Fazure\-marketplace%2F[a-z\-]+%2Fsrc/g;
+    var newContent = content.replace(link, "https://raw.githubusercontent.com/elastic/azure-marketplace/" + branch + "/src");
+    newContent = newContent.replace(escapedLink, "https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fazure-marketplace%2F" + branch + "%2Fsrc");
+    fs.writeFile(fileName, newContent, error); 
+  }
+
+  git.branch(function (branch) {
+    var branchName = argv.branch || branch;
+    ["../src/", "../parameters/"].forEach((dir) => { readFiles(dir, branchName, replaceLinks, error) });
+    fs.readFile("../README.md", 'utf-8', (err, content) => {
+      if (err) {
+        onError(err);
+        return;
+      }
+      replaceLinks("../README.md", content, branchName);
+    }); 
   });
 });

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "release": "gulp --gulpfile build/gulpfile.js release",
     "headless": "gulp --gulpfile build/gulpfile.js headless",
     "azure-cleanup": "gulp --gulpfile build/gulpfile.js azure-cleanup",
-    "deploy-all": "gulp --gulpfile build/gulpfile.js deploy-all"
+    "deploy-all": "gulp --gulpfile build/gulpfile.js deploy-all",
+    "links": "gulp --gulpfile build/gulpfile.js links"
   },
   "repository": {
     "type": "git",
@@ -48,6 +49,7 @@
     "mkdirp": "^0.5.1",
     "phantomjs-prebuilt": "^2.1.7",
     "request": "^2.72.0",
-    "requiredir": "^1.0.7"
+    "requiredir": "^1.0.7",
+    "yargs": "^6.0.0"
   }
 }

--- a/parameters/password.parameters.json
+++ b/parameters/password.parameters.json
@@ -2,6 +2,13 @@
 	"artifactsBaseUrl":{"value":"https://raw.githubusercontent.com/elastic/azure-marketplace/master/src"},
 	"esVersion":{"value":"2.2.0"},
 	"esClusterName":{"value":"my-azure-cluster"},
+	"location":{"value":"ResourceGroup"},
+	"esPlugins":{"value":"Yes"},
+	"cloudAzureStorageAccountName":{"value":"essnapshot"},
+	"cloudAzureStorageAccountExistingResourceGroup":{"value":""},
+	"cloudAzureStorageAccountNewType":{"value":"Standard_LRS"},
+	"cloudAzureStorageAccountNewOrExisting":{"value":"new"},
+	"cloudAzureStorageAccountNewUnique":{"value":"No"},
 	"loadBalancerType":{"value":"internal"},
 	"kibana":{"value":"Yes"},
 	"jumpbox":{"value":"No"},
@@ -31,5 +38,6 @@
 	"userEmail": { "value": "" },
 	"userFirstName": { "value": "" },	
 	"userLastName": { "value": "" },
-	"userJobTitle": { "value": "" }
+	"userJobTitle": { "value": "" },
+	"userCountry": { "value": "" }
 }

--- a/parameters/ssh.parameters.json
+++ b/parameters/ssh.parameters.json
@@ -2,6 +2,13 @@
 	"artifactsBaseUrl":{"value":"https://raw.githubusercontent.com/elastic/azure-marketplace/master/src"},
 	"esVersion":{"value":"2.2.0"},
 	"esClusterName":{"value":"my-azure-cluster"},
+	"location":{"value":"ResourceGroup"},
+	"esPlugins":{"value":"Yes"},
+	"cloudAzureStorageAccountName":{"value":"essnapshot"},
+	"cloudAzureStorageAccountExistingResourceGroup":{"value":""},
+	"cloudAzureStorageAccountNewType":{"value":"Standard_LRS"},
+	"cloudAzureStorageAccountNewOrExisting":{"value":"new"},
+	"cloudAzureStorageAccountNewUnique":{"value":"No"},
 	"loadBalancerType":{"value":"internal"},
 	"kibana":{"value":"Yes"},
 	"jumpbox":{"value":"No"},
@@ -31,5 +38,6 @@
 	"userEmail": { "value": "" },
 	"userFirstName": { "value": "" },	
 	"userLastName": { "value": "" },
-	"userJobTitle": { "value": "" }	
+	"userJobTitle": { "value": "" },
+	"userCountry": { "value": "" }	
 }

--- a/src/createUiDefinition.json
+++ b/src/createUiDefinition.json
@@ -141,18 +141,27 @@
             }
           },
           {
-            "name": "storageAccountName",
-            "type": "Microsoft.Common.TextBox",
-            "label": "Azure Storage Account Name",
-            "defaultValue": "",
-            "toolTip": "The name of the storage account to use for snapshots with Cloud Azure plugin"
-          },
-          {
-            "name": "storageAccountKey",
-            "type": "Microsoft.Common.PasswordBox",
-            "label": "Azure Storage Account Key",
-            "defaultValue": "",
-            "toolTip": "The storage account key to use for the storage account with Cloud Azure plugin"
+            "name": "cloudAzureStorageAccount",
+            "type": "Microsoft.Storage.StorageAccountSelector",
+            "label": "Azure Plugin Storage Account",
+            "toolTip": "The storage account to use for snapshots with Azure Cloud plugin",
+            "defaultValue": {
+              "name": "essnapshot",
+              "type": "Standard_LRS"
+            },
+            "constraints": {
+              "allowedTypes": [
+                "Standard_LRS",
+                "Standard_ZRS",
+                "Standard_GRS"
+              ],
+              "excludedTypes": [],
+              "required": true
+            },
+            "options": {
+              "hideExisting": false
+            },
+            "visible": true
           }
         ]
       },
@@ -174,7 +183,7 @@
             "constraints": {
               "required": false,
               "regex": "^[0-9a-zA-Z][0-9a-zA-Z\\-]{0,4}$",
-              "validationMessage": "Host name prefix must start with an alphanumeric character and can contain alphanumeric, underscore or hyphen characters, up to 5 characters in length"
+              "validationMessage": "Host name prefix must start with an alphanumeric character and can contain alphanumeric or hyphen characters, up to 5 characters in length"
             }
           },
           {
@@ -939,8 +948,11 @@
     "outputs": {
       "esVersion": "[steps('clusterSettingsStep').esVersion]",
       "esClusterName": "[steps('clusterSettingsStep').esClusterName]",
-      "storageAccountName": "[steps('clusterSettingsStep').storageAccountName]",
-      "storageAccountKey": "[steps('clusterSettingsStep').storageAccountKey]",
+      "cloudAzureStorageAccountName": "[steps('clusterSettingsStep').cloudAzureStorageAccount.name]",
+      "cloudAzureStorageAccountExistingResourceGroup": "[steps('clusterSettingsStep').cloudAzureStorageAccount.resourceGroup]",
+      "cloudAzureStorageAccountNewType": "[steps('clusterSettingsStep').cloudAzureStorageAccount.type]",
+      "cloudAzureStorageAccountNewOrExisting": "[steps('clusterSettingsStep').cloudAzureStorageAccount.newOrExisting]",
+      "cloudAzureStorageAccountNewUnique": "Yes",
       "loadBalancerType": "[steps('externalAccessStep').loadBalancerType]",
       "vNetNewOrExisting": "[steps('clusterSettingsStep').virtualNetwork.newOrExisting]",
       "vNetName": "[steps('clusterSettingsStep').virtualNetwork.name]",

--- a/src/empty/empty-jumpbox-resources.json
+++ b/src/empty/empty-jumpbox-resources.json
@@ -32,7 +32,7 @@
       }
     },
     "credentials": {
-      "type": "secureobject",
+      "type": "secureObject",
       "metadata": {
         "description": "Credential information block"
       }

--- a/src/empty/empty-kibana-resources.json
+++ b/src/empty/empty-kibana-resources.json
@@ -34,7 +34,7 @@
       }
     },
     "credentials": {
-      "type": "secureobject",
+      "type": "secureObject",
       "metadata": {
         "description": "Credentials information block"
       }

--- a/src/machines/client-nodes-resources.json
+++ b/src/machines/client-nodes-resources.json
@@ -14,8 +14,8 @@
       "metadata": {
         "description": "vm configuration"
       }
-      }
-    },
+    }
+  },
   "variables": {
     "namespace" : "[parameters('vm').namespace]"
   },
@@ -57,8 +57,7 @@
           "index": {
             "value": "[copyindex()]"
           }
-            }
         }
-        }
-      ]
-    }
+      }
+    }]
+}

--- a/src/machines/jumpbox-resources.json
+++ b/src/machines/jumpbox-resources.json
@@ -34,7 +34,7 @@
       }
     },
     "credentials": {
-      "type": "secureobject",
+      "type": "secureObject",
       "metadata": {
         "description": "Credential information block"
       }

--- a/src/machines/kibana-resources.json
+++ b/src/machines/kibana-resources.json
@@ -34,7 +34,7 @@
       }
     },
     "credentials": {
-      "type": "secureobject",
+      "type": "secureObject",
       "metadata": {
         "description": "Credentials information block"
       }
@@ -50,7 +50,7 @@
       "defaultValue": "Standard_A1",
       "metadata": {
         "description": "Size of the Elasticsearch master nodes"
-    }
+      }
     }
   },
   "variables": {

--- a/src/machines/master-nodes-resources.json
+++ b/src/machines/master-nodes-resources.json
@@ -14,8 +14,8 @@
       "metadata": {
         "description": "vm configuration"
       }
-      }
-    },
+    }
+  },
   "variables": {
     "namespace" : "[parameters('vm').namespace]"
   },

--- a/src/mainTemplate.json
+++ b/src/mainTemplate.json
@@ -33,18 +33,54 @@
         "description": "The name of the Elasticsearch cluster"
       }
     },
-    "storageAccountName": {
+    "cloudAzureStorageAccountName": {
+      "type": "string",
+      "defaultValue": "essnapshot",
+      "minLength": 3,
+      "maxLength": 24,
+      "metadata": {
+        "description": "The name of the storage account to use for snapshots with Azure Cloud plugin. Must be between 3 and 24 alphanumeric lowercase characters."
+      }
+    },
+    "cloudAzureStorageAccountExistingResourceGroup": {
       "type": "string",
       "defaultValue": "",
       "metadata": {
-        "description": "The name of the storage account to use for snapshots with Cloud Azure plugin"
+        "description": "The name of the resource group in which an existing storage account resides to use for snapshots with Azure Cloud plugin"
       }
     },
-    "storageAccountKey": {
-      "type": "securestring",
-      "defaultValue": "",
+    "cloudAzureStorageAccountNewType": {
+      "type": "string",
+      "defaultValue": "Standard_LRS",
+      "allowedValues": [
+        "Standard_LRS",
+        "Standard_ZRS",
+        "Standard_GRS"
+      ],
       "metadata": {
-        "description": "The storage account key to use for the storage account with Cloud Azure plugin"
+        "description": "The type of new storage account for snapshots with Azure Cloud plugin"
+      }
+    },
+    "cloudAzureStorageAccountNewOrExisting": {
+      "type": "string",
+      "defaultValue": "new",
+      "allowedValues": [
+        "new",
+        "existing"
+      ],
+      "metadata": {
+        "description": "Choose to create a new storage account or use an existing one for snapshots with Azure Cloud plugin"
+      }
+    },
+    "cloudAzureStorageAccountNewUnique": {
+      "type": "string",
+      "defaultValue": "No",
+      "allowedValues": [
+        "Yes",
+        "No"
+      ],
+      "metadata": {
+        "description": "Whether the new storage account to use for snapshots has been validated to be unique. If set to Yes then the new storage account name will be taken verbatim; if set to No then the first 11 characters of the storage account name will be taken as a prefix to a randomly generated unique storage account name"
       }
     },
     "loadBalancerType": {
@@ -55,7 +91,7 @@
         "external"
       ],
       "metadata": {
-        "description": "Setup the load balancer internal or external.  If you are setting up Elasticsearch on an external endpoint you will need to secure your nodes with a product like Elasticsearch Shield"
+        "description": "Setup the load balancer as internal or external. If you are setting up Elasticsearch on an external endpoint you will need to secure your nodes with a product like Elastic's Shield"
       }
     },
     "esPlugins": {
@@ -66,7 +102,7 @@
       ],
       "defaultValue": "Yes",
       "metadata": {
-        "description": "Install the Plugins - Marvel, Shield, Watcher, Graph"
+        "description": "Install the Plugins - Marvel, Shield, Watcher, Graph* (Elasticsearch version permitting)"
       }
     },
     "kibana": {
@@ -448,7 +484,11 @@
         "centralindia",
         "westindia",
         "canadacentral",
-        "canadaeast"
+        "canadaeast",
+        "uksouth",
+        "ukwest",
+        "westcentralus",
+        "westus2"
       ],
       "defaultValue": "ResourceGroup",
       "metadata": {
@@ -566,6 +606,34 @@
     }
   },
   "variables": {
+    "locationMap": {
+      "ResourceGroup": "[resourceGroup().location]",
+      "eastasia": "[resourceGroup().location]",
+      "southeastasia": "[resourceGroup().location]",
+      "centralus": "[resourceGroup().location]",
+      "eastus": "[resourceGroup().location]",
+      "eastus2": "[resourceGroup().location]",
+      "westus": "[resourceGroup().location]",
+      "northcentralus": "[resourceGroup().location]",
+      "southcentralus": "[resourceGroup().location]",
+      "northeurope": "[resourceGroup().location]",
+      "westeurope": "[resourceGroup().location]",
+      "japanwest": "[resourceGroup().location]",
+      "japaneast": "[resourceGroup().location]",
+      "brazilsouth": "[resourceGroup().location]",
+      "australiaeast": "[resourceGroup().location]",
+      "australiasoutheast": "[resourceGroup().location]",
+      "southindia": "[resourceGroup().location]",
+      "centralindia": "[resourceGroup().location]",
+      "westindia": "[resourceGroup().location]",
+      "canadacentral": "[resourceGroup().location]",
+      "canadaeast": "[resourceGroup().location]",
+      "uksouth": "[resourceGroup().location]",
+      "ukwest": "[resourceGroup().location]",
+      "westcentralus": "[resourceGroup().location]",
+      "westus2": "[resourceGroup().location]"
+    },
+    "location": "[variables('locationMap')[parameters('location')]]",
     "templateBaseUrl": "[concat(parameters('artifactsBaseUrl'), '/')]",
     "sharedTemplateUrl": "[concat(variables('templateBaseUrl'), '/partials/shared-resources.json')]",
     "loadBalancerTemplateUrl": "[concat(variables('templateBaseUrl'), '/loadbalancers/', parameters('loadBalancerType') ,'-lb-resources.json')]",
@@ -590,6 +658,31 @@
     ],
     "clientResourceIndex": "[mod(add(parameters('vmClientNodeCount'),2),add(parameters('vmClientNodeCount'),1))]",
     "clientTemplateUrl": "[concat(variables('templateBaseUrl'), variables('clientTemplates')[variables('clientResourceIndex')])]",
+    "cloudAzureStorageAccountTemplates": {
+      "new": "storageAccounts/new-storage-account.json",
+      "existing": "storageAccounts/existing-storage-account.json"
+    },
+    "cloudAzureStorageAccountNameMap": {
+      "new": {
+        "Yes": "[parameters('cloudAzureStorageAccountName')]",
+        "No": "[concat(take(parameters('cloudAzureStorageAccountName'), 11), uniqueString(resourceGroup().id, subscription().id, deployment().name))]"
+      },
+      "existing": {
+        "Yes": "[parameters('cloudAzureStorageAccountName')]",
+        "No": "[parameters('cloudAzureStorageAccountName')]"
+      }
+    },
+    "cloudAzureStorageAccountResourceGroupMap": {
+      "new": "[resourceGroup().name]",
+      "existing": "[parameters('cloudAzureStorageAccountExistingResourceGroup')]"
+    },
+    "cloudAzureStorageAccountTemplateUrl": "[concat(variables('templateBaseUrl'), variables('cloudAzureStorageAccountTemplates')[parameters('cloudAzureStorageAccountNewOrExisting')])]",
+    "cloudAzureStorageAccount": {
+      "name": "[variables('cloudAzureStorageAccountNameMap')[parameters('cloudAzureStorageAccountNewOrExisting')][parameters('cloudAzureStorageAccountNewUnique')]]",
+      "type": "[parameters('cloudAzureStorageAccountNewType')]",
+      "resourceGroup": "[variables('cloudAzureStorageAccountResourceGroupMap')[parameters('cloudAzureStorageAccountNewOrExisting')]]",
+      "location": "[variables('location')]"
+    },
     "credentials": {
       "adminUsername": "[parameters('adminUsername')]",
       "password": "[parameters('adminPassword')]",
@@ -624,118 +717,24 @@
       "No": "0",
       "Yes": "1"
     },
-    "clusterSetup": "[concat('m=', variables('masterNodeCount')[parameters('dataNodesAreMasterEligible')], ' ', parameters('vmSizeMasterNodes'), ',d=', parameters('vmDataNodeCount'), ' ', parameters('vmSizeDataNodes'), ',c=', parameters('vmClientNodeCount'), ' ', parameters('vmSizeClientNodes'), ',k=', variables('kibanajumpboxNodeCount')[parameters('kibana')], ' ', parameters('vmSizeKibana'), ',j=', variables('kibanajumpboxNodeCount')[parameters('jumpbox')], ' Standard_A0', ',l=', parameters('loadBalancerType'))]",
     "namespacePrefix": "[parameters('vmHostNamePrefix')]",
-    "dataNodeShortOpts": {
-      "No": "z",
-      "Yes": ""
+    "clusterSetup": {
+      "dataNodesAreMasterEligible": "[parameters('dataNodesAreMasterEligible')]",
+      "vmDataNodeCount": "[parameters('vmDataNodeCount')]",
+      "vmHostNamePrefix": "[variables('namespacePrefix')]",
+      "vNetLoadBalancerIp": "[parameters('vNetLoadBalancerIp')]",
+      "setup": "[concat('m=', variables('masterNodeCount')[parameters('dataNodesAreMasterEligible')], ' ', parameters('vmSizeMasterNodes'), ',d=', parameters('vmDataNodeCount'), ' ', parameters('vmSizeDataNodes'), ',c=', parameters('vmClientNodeCount'), ' ', parameters('vmSizeClientNodes'), ',k=', variables('kibanajumpboxNodeCount')[parameters('kibana')], ' ', parameters('vmSizeKibana'), ',j=', variables('kibanajumpboxNodeCount')[parameters('jumpbox')], ' Standard_A0', ',l=', parameters('loadBalancerType'))]"
     },
-    "dataNodeShortOpt": "[variables('dataNodeShortOpts')[parameters('dataNodesAreMasterEligible')]]",
-    "dedicatedMasterNodesShortOpts": {
-      "No": "d",
-      "Yes": ""
-    },
-    "dedicatedMasterNodesShortOpt": "[variables('dedicatedMasterNodesShortOpts')[parameters('dataNodesAreMasterEligible')]]",
-    "installPluginsShortOpts": {
-      "No": "",
-      "Yes": "l"
-    },
-    "installPluginsShortOpt": "[variables('installPluginsShortOpts')[variables('esSettings').installPlugins]]",
-    "commonShortOpts": "[concat(variables('dedicatedMasterNodesShortOpt'),  variables('installPluginsShortOpt'), 'n ')]",
-    "commonInstallParams": "[concat(variables('esSettings').clusterName, ' -v ', variables('esSettings').version, ' -A ', variables('esSettings').shieldAdminPwd, ' -R ', variables('esSettings').shieldReadPwd, ' -K ', variables('esSettings').shieldKibanaPwd, ' -S ', variables('esSettings').shieldKibanaServerPwd, ' -Z ', parameters('vmDataNodeCount'), ' -p \"', variables('namespacePrefix'), '\" -a \"', parameters('storageAccountName'), '\" -k \"', parameters('storageAccountKey'), '\"')]",
-    "ubuntuScripts": [
-      "[concat(variables('templateBaseUrl'), 'scripts/elasticsearch-ubuntu-install.sh')]",
-      "[concat(variables('templateBaseUrl'), 'scripts/kibana-install.sh')]",
-      "[concat(variables('templateBaseUrl'), 'scripts/vm-disk-utils-0.1.sh')]",
-      "[concat(variables('templateBaseUrl'), 'scripts/user-information.sh')]",
-      "[concat(variables('templateBaseUrl'), 'scripts/data-node-install.sh')]"
-    ],
-    "clientInstallScript": "[concat('bash elasticsearch-ubuntu-install.sh -y', variables('commonShortOpts'), variables('commonInstallParams'))]",
-    "ubuntuSettings": {
-      "imageReference": {
-        "publisher": "Canonical",
-        "offer": "UbuntuServer",
-        "sku": "14.04.4-LTS",
-        "version": "latest"
-      },
-      "managementPort": "22",
-      "extensionSettings": {
-        "master": {
-          "publisher": "Microsoft.OSTCExtensions",
-          "type": "CustomScriptForLinux",
-          "typeHandlerVersion": "1.5",
-          "autoUpgradeMinorVersion": true,
-          "settings": {
-            "fileUris": "[variables('ubuntuScripts')]"
-          },
-          "protectedSettings": {
-            "commandToExecute": "[concat('bash elasticsearch-ubuntu-install.sh -x', variables('commonShortOpts'), variables('commonInstallParams'))]"
-          }
-        },
-        "client": {
-          "publisher": "Microsoft.OSTCExtensions",
-          "type": "CustomScriptForLinux",
-          "typeHandlerVersion": "1.5",
-          "autoUpgradeMinorVersion": true,
-          "settings": {
-            "fileUris": "[variables('ubuntuScripts')]"
-          },
-          "protectedSettings": {
-            "commandToExecute": "[variables('clientInstallScript')]"
-          }
-        },
-        "data": {
-          "publisher": "Microsoft.OSTCExtensions",
-          "type": "CustomScriptForLinux",
-          "typeHandlerVersion": "1.5",
-          "autoUpgradeMinorVersion": true,
-          "settings": {
-            "fileUris": "[variables('ubuntuScripts')]"
-          },
-          "protectedSettings": {
-            "commandToExecute": "[concat('bash data-node-install.sh -', variables('dataNodeShortOpt'), variables('commonShortOpts'), variables('commonInstallParams'), ' -U \"http://app-lon02.marketo.com/index.php/leadCapture/save2\" -I \"813-MAM-392\" -c \"', parameters('userCompany'), '\" -e \"', parameters('userEmail'), '\" -f \"', parameters('userFirstName'), '\" -m \"', parameters('userLastName'), '\" -t \"', parameters('userJobTitle'), '\" -s \"', variables('clusterSetup'), '\" -o \"', parameters('userCountry'), '\"')]"
-          }
-        },
-        "kibana": {
-          "publisher": "Microsoft.OSTCExtensions",
-          "type": "CustomScriptForLinux",
-          "typeHandlerVersion": "1.5",
-          "autoUpgradeMinorVersion": true,
-          "settings": {
-            "fileUris": "[variables('ubuntuScripts')]"
-          },
-          "protectedSettings": {
-            "commandToExecute": "[concat('bash kibana-install.sh -', variables('installPluginsShortOpt'), 'n ', variables('esSettings').clusterName, ' -v ', variables('esSettings').kibanaVersion, ' -e ', variables('esSettings').version, ' -u ', concat('http://', parameters('vNetLoadBalancerIp'), ':9200') ,' -S ', variables('esSettings').shieldKibanaServerPwd)]"
-          }
-        }
-      }
+    "userDetails": {
+      "email": "[parameters('userEmail')]",
+      "firstName": "[parameters('userFirstName')]",
+      "lastName": "[parameters('userLastName')]",
+      "jobTitle": "[parameters('userJobTitle')]",
+      "company": "[parameters('userCompany')]",
+      "country": "[parameters('userCountry')]"
     },
     "OS": "ubuntu",
-    "osSettings": "[variables(concat(variables('OS'), 'Settings'))]",
-    "locationMap": {
-      "ResourceGroup": "[resourceGroup().location]",
-      "eastasia": "[resourceGroup().location]",
-      "southeastasia": "[resourceGroup().location]",
-      "centralus": "[resourceGroup().location]",
-      "eastus": "[resourceGroup().location]",
-      "eastus2": "[resourceGroup().location]",
-      "westus": "[resourceGroup().location]",
-      "northcentralus": "[resourceGroup().location]",
-      "southcentralus": "[resourceGroup().location]",
-      "northeurope": "[resourceGroup().location]",
-      "westeurope": "[resourceGroup().location]",
-      "japanwest": "[resourceGroup().location]",
-      "japaneast": "[resourceGroup().location]",
-      "brazilsouth": "[resourceGroup().location]",
-      "australiaeast": "[resourceGroup().location]",
-      "australiasoutheast": "[resourceGroup().location]",
-      "southindia": "[resourceGroup().location]",
-      "centralindia": "[resourceGroup().location]",
-      "westindia": "[resourceGroup().location]",
-      "canadacentral": "[resourceGroup().location]",
-      "canadaeast": "[resourceGroup().location]"
-    },
-    "location": "[variables('locationMap')[parameters('location')]]",
+    "osSettingsTemplateUrl": "[concat(variables('templateBaseUrl'), 'settings/', variables('OS'), 'Settings.json')]",
     "storageAccountPrefix": "elastic",
     "storageAccountNameShared": "[concat(variables('storageAccountPrefix'), 's', uniqueString(resourceGroup().id, deployment().name))]",
     "networkTemplateUrl": "[concat(variables('templateBaseUrl'), 'networks/', parameters('vNetNewOrExisting'), '-virtual-network.json')]",
@@ -1065,8 +1064,7 @@
       "location": "[variables('location')]",
       "subnet": "[variables('networkSettings').subnet]",
       "subnetId": "[concat(resourceId(variables('networkSettings').resourceGroup, 'Microsoft.Network/virtualNetworks', variables('networkSettings').name), '/subnets/', variables('networkSettings').subnet.name)]",
-      "credentials": "[variables('credentials')]",
-      "osSettings": "[variables('osSettings')]"
+      "credentials": "[variables('credentials')]"
     }
   },
   "resources": [
@@ -1086,6 +1084,23 @@
           },
           "storageAccountName": {
             "value": "[variables('storageAccountNameShared')]"
+          }
+        }
+      }
+    },
+    {
+      "name": "cloud-azure-storage-account",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2016-02-01",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('cloudAzureStorageAccountTemplateUrl')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "cloudAzureStorageAccount": {
+            "value": "[variables('cloudAzureStorageAccount')]"
           }
         }
       }
@@ -1113,7 +1128,8 @@
       "apiVersion": "2016-02-01",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', 'shared')]",
-        "[concat('Microsoft.Resources/deployments/', 'network')]"
+        "[concat('Microsoft.Resources/deployments/', 'network')]",
+        "[concat('Microsoft.Resources/deployments/', 'cloud-azure-storage-account')]"
       ],
       "properties": {
         "mode": "Incremental",
@@ -1129,11 +1145,47 @@
       }
     },
     {
+      "name": "os-settings",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2016-02-01",
+      "dependsOn": [
+        "[concat('Microsoft.Resources/deployments/', 'cloud-azure-storage-account')]"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('osSettingsTemplateUrl')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "esSettings": {
+            "value": "[variables('esSettings')]"
+          },
+          "userDetails": {
+            "value": "[variables('userDetails')]"
+          },
+          "clusterSetup": {
+            "value": "[variables('clusterSetup')]"
+          },
+          "templateBaseUrl": {
+            "value": "[variables('templateBaseUrl')]"
+          },
+          "cloudAzureStorageAccount": {
+            "value": {
+              "name": "[reference('cloud-azure-storage-account').outputs.name.value]",
+              "key": "[reference('cloud-azure-storage-account').outputs.key.value]"
+            }
+          }
+        }
+      }
+    },
+    {
       "name": "master-nodes",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2016-02-01",
       "dependsOn": [
-        "[concat('Microsoft.Resources/deployments/', 'loadbalancer')]"
+        "[concat('Microsoft.Resources/deployments/', 'loadbalancer')]",
+        "[concat('Microsoft.Resources/deployments/', 'os-settings')]"
       ],
       "properties": {
         "mode": "Incremental",
@@ -1149,12 +1201,13 @@
             "value": {
               "shared": "[variables('sharedVmConfig')]",
               "namespace": "[concat(variables('namespacePrefix'), 'master-')]",
-              "installScript": "[variables('osSettings').extensionSettings.master]",
+              "installScript": "[reference('os-settings').outputs.settings.value.extensionSettings.master]",
               "size": "[parameters('vmSizeMasterNodes')]",
               "count": 3,
               "useSharedStorageAccount": "Yes",
               "useBackendPools": "No",
-              "backendPools": []
+              "backendPools": [],
+              "imageReference": "[reference('os-settings').outputs.settings.value.imageReference]"
             }
           }
         }
@@ -1165,7 +1218,8 @@
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2016-02-01",
       "dependsOn": [
-        "[concat('Microsoft.Resources/deployments/', 'loadbalancer')]"
+        "[concat('Microsoft.Resources/deployments/', 'loadbalancer')]",
+        "[concat('Microsoft.Resources/deployments/', 'os-settings')]"
       ],
       "properties": {
         "mode": "Incremental",
@@ -1181,12 +1235,13 @@
             "value": {
               "shared": "[variables('sharedVmConfig')]",
               "namespace": "[concat(variables('namespacePrefix'), 'client-')]",
-              "installScript": "[variables('osSettings').extensionSettings.client]",
+              "installScript": "[reference('os-settings').outputs.settings.value.extensionSettings.client]",
               "size": "[parameters('vmSizeClientNodes')]",
               "count": "[parameters('vmClientNodeCount')]",
               "useSharedStorageAccount": "Yes",
               "useBackendPools": "Yes",
-              "backendPools": "[variables('lbBackEndPoolsAdded').backendPools]"
+              "backendPools": "[variables('lbBackEndPoolsAdded').backendPools]",
+              "imageReference": "[reference('os-settings').outputs.settings.value.imageReference]"
             }
           }
         }
@@ -1197,7 +1252,8 @@
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2016-02-01",
       "dependsOn": [
-        "[concat('Microsoft.Resources/deployments/', 'loadbalancer')]"
+        "[concat('Microsoft.Resources/deployments/', 'loadbalancer')]",
+        "[concat('Microsoft.Resources/deployments/', 'os-settings')]"
       ],
       "properties": {
         "mode": "Incremental",
@@ -1213,12 +1269,13 @@
             "value": {
               "shared": "[variables('sharedVmConfig')]",
               "namespace": "[concat(variables('namespacePrefix'), 'data-')]",
-              "installScript": "[variables('osSettings').extensionSettings.data]",
+              "installScript": "[reference('os-settings').outputs.settings.value.extensionSettings.data]",
               "size": "[parameters('vmSizeDataNodes')]",
               "count": "[parameters('vmDataNodeCount')]",
               "useSharedStorageAccount": "No",
               "useBackendPools": "Yes",
-              "backendPools": "[variables('dataLBSettings').backendPools]"
+              "backendPools": "[variables('dataLBSettings').backendPools]",
+              "imageReference": "[reference('os-settings').outputs.settings.value.imageReference]"
             }
           },
           "storageSettings": {
@@ -1232,7 +1289,8 @@
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2016-02-01",
       "dependsOn": [
-        "[concat('Microsoft.Resources/deployments/', 'loadbalancer')]"
+        "[concat('Microsoft.Resources/deployments/', 'loadbalancer')]",
+        "[concat('Microsoft.Resources/deployments/', 'os-settings')]"
       ],
       "properties": {
         "mode": "Incremental",
@@ -1260,7 +1318,7 @@
             "value": "[variables('networkSettings')]"
           },
           "osSettings": {
-            "value": "[variables('osSettings')]"
+            "value": "[reference('os-settings').outputs.settings.value]"
           }
         }
       }
@@ -1270,7 +1328,8 @@
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2016-02-01",
       "dependsOn": [
-        "[concat('Microsoft.Resources/deployments/', 'loadbalancer')]"
+        "[concat('Microsoft.Resources/deployments/', 'loadbalancer')]",
+        "[concat('Microsoft.Resources/deployments/', 'os-settings')]"
       ],
       "properties": {
         "mode": "Incremental",
@@ -1298,7 +1357,7 @@
             "value": "[variables('networkSettings')]"
           },
           "osSettings": {
-            "value": "[variables('osSettings')]"
+            "value": "[reference('os-settings').outputs.settings.value]"
           },
           "vmSize": {
             "value": "[parameters('vmSizeKibana')]"

--- a/src/partials/vm.json
+++ b/src/partials/vm.json
@@ -98,7 +98,7 @@
         },
         "osProfile": "[variables('osProfile')]",
         "storageProfile": {
-          "imageReference": "[parameters('vm').shared.osSettings.imageReference]",
+          "imageReference": "[parameters('vm').imageReference]",
           "osDisk": {
             "name": "osdisk",
             "vhd": {

--- a/src/scripts/elasticsearch-ubuntu-install.sh
+++ b/src/scripts/elasticsearch-ubuntu-install.sh
@@ -358,12 +358,12 @@ configure_elasticsearch_yaml()
     echo "discovery.zen.minimum_master_nodes: $MINIMUM_MASTER_NODES" >> /etc/elasticsearch/elasticsearch.yml
     echo "network.host: _non_loopback_" >> /etc/elasticsearch/elasticsearch.yml
 
-    # Configure Cloud Azure plugin
+    # Configure Azure Cloud plugin
     if [[ -n "$STORAGE_ACCOUNT" && -n "$STORAGE_KEY" ]]; then
-        log "[configure_elasticsearch_yaml] Configuring storage for Cloud Azure"
+        log "[configure_elasticsearch_yaml] Configuring storage for Azure Cloud"
         echo "cloud.azure.storage.default.account: ${STORAGE_ACCOUNT}" >> /etc/elasticsearch/elasticsearch.yml
         echo "cloud.azure.storage.default.key: ${STORAGE_KEY}" >> /etc/elasticsearch/elasticsearch.yml
-        log "[configure_elasticsearch_yaml] Configured storage for Cloud Azure"
+        log "[configure_elasticsearch_yaml] Configured storage for Azure Cloud"
     fi
 
     echo "marvel.agent.enabled: true" >> /etc/elasticsearch/elasticsearch.yml

--- a/src/settings/ubuntuSettings.json
+++ b/src/settings/ubuntuSettings.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+      "esSettings": {
+          "type": "object",
+          "metadata": {
+              "description" : "The Elasticsearch settings"
+          }
+      },
+      "userDetails": {
+          "type": "object",
+          "metadata": {
+              "description": "User details"
+          }
+      },
+      "clusterSetup": {
+          "type": "object",
+          "metadata": {
+              "description": "Cluster deployment settings"
+          }
+      },
+      "templateBaseUrl": {
+          "type": "string",
+          "metadata": {
+              "description": "The base url for templates"
+          }
+      },
+      "cloudAzureStorageAccount": {
+          "type": "object",
+          "metadata": {
+              "description": "The storage settings for the Azure Cloud plugin"
+          }
+      }
+  },
+  "variables": {
+    "clusterSetup": "[parameters('clusterSetup').setup]",
+    "namespacePrefix": "[parameters('clusterSetup').vmHostNamePrefix]",
+    "dataNodeShortOpts": {
+      "No": "z",
+      "Yes": ""
+    },
+    "dataNodeShortOpt": "[variables('dataNodeShortOpts')[parameters('clusterSetup').dataNodesAreMasterEligible]]",
+    "dedicatedMasterNodesShortOpts": {
+      "No": "d",
+      "Yes": ""
+    },
+    "dedicatedMasterNodesShortOpt": "[variables('dedicatedMasterNodesShortOpts')[parameters('clusterSetup').dataNodesAreMasterEligible]]",
+    "installPluginsShortOpts": {
+      "No": "",
+      "Yes": "l"
+    },
+    "installPluginsShortOpt": "[variables('installPluginsShortOpts')[parameters('esSettings').installPlugins]]",
+    "commonShortOpts": "[concat(variables('dedicatedMasterNodesShortOpt'),  variables('installPluginsShortOpt'), 'n ')]",
+    "commonInstallParams": "[concat(parameters('esSettings').clusterName, ' -v ', parameters('esSettings').version, ' -A ', parameters('esSettings').shieldAdminPwd, ' -R ', parameters('esSettings').shieldReadPwd, ' -K ', parameters('esSettings').shieldKibanaPwd, ' -S ', parameters('esSettings').shieldKibanaServerPwd, ' -Z ', parameters('clusterSetup').vmDataNodeCount, ' -p \"', variables('namespacePrefix'), '\" -a \"', parameters('cloudAzureStorageAccount').name, '\" -k \"', parameters('cloudAzureStorageAccount').key, '\"')]",
+    "ubuntuScripts": [
+      "[concat(parameters('templateBaseUrl'), 'scripts/elasticsearch-ubuntu-install.sh')]",
+      "[concat(parameters('templateBaseUrl'), 'scripts/kibana-install.sh')]",
+      "[concat(parameters('templateBaseUrl'), 'scripts/vm-disk-utils-0.1.sh')]",
+      "[concat(parameters('templateBaseUrl'), 'scripts/user-information.sh')]",
+      "[concat(parameters('templateBaseUrl'), 'scripts/data-node-install.sh')]"
+    ],
+    "clientInstallScript": "[concat('bash elasticsearch-ubuntu-install.sh -y', variables('commonShortOpts'), variables('commonInstallParams'))]",
+    "ubuntuSettings": {
+      "imageReference": {
+        "publisher": "Canonical",
+        "offer": "UbuntuServer",
+        "sku": "14.04.4-LTS",
+        "version": "latest"
+      },
+      "managementPort": "22",
+      "extensionSettings": {
+        "master": {
+          "publisher": "Microsoft.OSTCExtensions",
+          "type": "CustomScriptForLinux",
+          "typeHandlerVersion": "1.5",
+          "autoUpgradeMinorVersion": true,
+          "settings": {
+            "fileUris": "[variables('ubuntuScripts')]"
+          },
+          "protectedSettings": {
+            "commandToExecute": "[concat('bash elasticsearch-ubuntu-install.sh -x', variables('commonShortOpts'), variables('commonInstallParams'))]"
+          }
+        },
+        "client": {
+          "publisher": "Microsoft.OSTCExtensions",
+          "type": "CustomScriptForLinux",
+          "typeHandlerVersion": "1.5",
+          "autoUpgradeMinorVersion": true,
+          "settings": {
+            "fileUris": "[variables('ubuntuScripts')]"
+          },
+          "protectedSettings": {
+            "commandToExecute": "[variables('clientInstallScript')]"
+          }
+        },
+        "data": {
+          "publisher": "Microsoft.OSTCExtensions",
+          "type": "CustomScriptForLinux",
+          "typeHandlerVersion": "1.5",
+          "autoUpgradeMinorVersion": true,
+          "settings": {
+            "fileUris": "[variables('ubuntuScripts')]"
+          },
+          "protectedSettings": {
+            "commandToExecute": "[concat('bash data-node-install.sh -', variables('dataNodeShortOpt'), variables('commonShortOpts'), variables('commonInstallParams'), ' -U \"http://app-lon02.marketo.com/index.php/leadCapture/save2\" -I \"813-MAM-392\" -c \"', parameters('userDetails').company, '\" -e \"', parameters('userDetails').email, '\" -f \"', parameters('userDetails').firstName, '\" -m \"', parameters('userDetails').lastName, '\" -t \"', parameters('userDetails').jobTitle, '\" -s \"', variables('clusterSetup'), '\" -o \"', parameters('userDetails').country, '\"')]"
+          }
+        },
+        "kibana": {
+          "publisher": "Microsoft.OSTCExtensions",
+          "type": "CustomScriptForLinux",
+          "typeHandlerVersion": "1.5",
+          "autoUpgradeMinorVersion": true,
+          "settings": {
+            "fileUris": "[variables('ubuntuScripts')]"
+          },
+          "protectedSettings": {
+            "commandToExecute": "[concat('bash kibana-install.sh -', variables('installPluginsShortOpt'), 'n ', parameters('esSettings').clusterName, ' -v ', parameters('esSettings').kibanaVersion, ' -e ', parameters('esSettings').version, ' -u ', concat('http://', parameters('clusterSetup').vNetLoadBalancerIp, ':9200') ,' -S ', parameters('esSettings').shieldKibanaServerPwd)]"
+          }
+        }
+      }
+    }
+  },
+  "resources": [
+  ],
+  "outputs": {
+    "settings": {
+        "value": "[variables('ubuntuSettings')]",
+        "type": "object"
+    }
+  }
+}

--- a/src/storageAccounts/existing-storage-account.json
+++ b/src/storageAccounts/existing-storage-account.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "cloudAzureStorageAccount": {
+      "type": "object",
+      "metadata": {
+        "description": "Storage account used for snapshots with Azure Cloud plugin"
+      }
+    }
+  },
+  "resources": [
+  ],
+  "outputs": {
+    "name": {
+      "type": "string",
+      "value": "[parameters('cloudAzureStorageAccount').name]"
+    },
+    "key": {
+      "type": "string",
+      "value": "[listKeys(resourceId(parameters('cloudAzureStorageAccount').resourceGroup, 'Microsoft.Storage/storageAccounts', parameters('cloudAzureStorageAccount').name), '2016-01-01').keys[0].value]"
+    }
+  }
+}

--- a/src/storageAccounts/new-storage-account.json
+++ b/src/storageAccounts/new-storage-account.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "cloudAzureStorageAccount": {
+      "type": "object",
+      "metadata": {
+        "description": "Storage account used for snapshots with Azure Cloud plugin"
+      }
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[parameters('cloudAzureStorageAccount').name]",
+      "apiVersion": "2016-01-01",
+      "location": "[parameters('cloudAzureStorageAccount').location]",
+      "sku": {
+        "name": "[parameters('cloudAzureStorageAccount').type]"
+      },
+      "kind": "Storage",
+      "properties": {
+      }
+    }
+  ],
+  "outputs": {
+    "name": {
+      "type": "string",
+      "value": "[parameters('cloudAzureStorageAccount').name]"
+    },
+    "key": {
+      "type": "string",
+      "value": "[listKeys(resourceId(parameters('cloudAzureStorageAccount').resourceGroup, 'Microsoft.Storage/storageAccounts', parameters('cloudAzureStorageAccount').name), '2016-01-01').keys[0].value]"
+    }
+  }
+}


### PR DESCRIPTION
- When selecting an existing storage account, take the name verbatim but when selecting a new storage account, use the first 11 characters as a prefix to a uniquely generated storage account name
- Add a gulp task to update all github links to the template to use the current branch name or optionally pass a branch name
- Output the storage account name and access key from the storage account resource configuration
- Move ubuntuSettings out into a separate script to allow the settings of the storage account name and key to be set in the script commands
- Allow all storage account types except Premium_LRS for Azure Cloud plugin. Opened issue: https://github.com/elastic/elasticsearch/issues/20765
- Update all arm validator tests to include storage account properties
- Include storageAccountNewUnique flag to indicate whether the storage account name has been validated to be unique and therefore can be used verbatim.
- Update README
- Include new Azure locations - uksouth, ukwest, westcentralus, westus2

Closes https://github.com/elastic/azure-marketplace/issues/54