### PR TITLE
Fix monit not monitoring elasticsearch before 1st VM reboot

### DIFF
--- a/src/scripts/elasticsearch-ubuntu-install.sh
+++ b/src/scripts/elasticsearch-ubuntu-install.sh
@@ -517,9 +517,9 @@ configure_elasticsearch
 
 configure_os_properties
 
-start_monit
-
 start_elasticsearch
+
+start_monit
 
 port_forward
 

--- a/src/scripts/elasticsearch-ubuntu-install.sh
+++ b/src/scripts/elasticsearch-ubuntu-install.sh
@@ -400,6 +400,7 @@ start_monit()
 {
     log "[start_monit] starting monit"
     sudo /etc/init.d/monit start
+    sudo monit reload # use the new configuration
     sudo monit start all
     log "[start_monit] started monit"
 }


### PR DESCRIPTION
* Monit will not monitor elasticsearch until its configuration is reloaded or monit is restarted.  Monit is started when installed so that `sudo /etc/init.d/monit start` has no effect. Chose to reload the monit configuration rather than restarting since it should be faster.
* After the monit configuration is reloaded it will notice that elasticsearch is not running and start it (as does `start_elasticsearch`).  Starting monit after elasticsearch avoids a race condition.