### PR TITLE
5.x support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ using in production.**
 
 ![Example UI Flow](images/ui.gif)
 
-You can view the UI in developer mode by [clicking here](https://portal.azure.com/#blade/Microsoft_Azure_Compute/CreateMultiVmWizardBlade/internal_bladeCallId/anything/internal_bladeCallerParams/{"initialData":{},"providerConfig":{"createUiDefinition":"https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fazure-marketplace%2Fmaster%2Fsrc%2FcreateUiDefinition.json"}}). If you feel something is cached improperly use [this client unoptimized link instead](https://portal.azure.com/?clientOptimizations=false#blade/Microsoft_Azure_Compute/CreateMultiVmWizardBlade/internal_bladeCallId/anything/internal_bladeCallerParams/{"initialData":{},"providerConfig":{"createUiDefinition":"https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fazure-marketplace%2Fmaster%2Fsrc%2FcreateUiDefinition.json"}})
+You can view the UI in developer mode by [clicking here](https://portal.azure.com/#blade/Microsoft_Azure_Compute/CreateMultiVmWizardBlade/internal_bladeCallId/anything/internal_bladeCallerParams/{"initialData":{},"providerConfig":{"createUiDefinition":"https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fazure-marketplace%2Ffeature/5x-support%2Fsrc%2FcreateUiDefinition.json"}}). If you feel something is cached improperly use [this client unoptimized link instead](https://portal.azure.com/?clientOptimizations=false#blade/Microsoft_Azure_Compute/CreateMultiVmWizardBlade/internal_bladeCallId/anything/internal_bladeCallerParams/{"initialData":{},"providerConfig":{"createUiDefinition":"https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fazure-marketplace%2Ffeature/5x-support%2Fsrc%2FcreateUiDefinition.json"}})
 
 ## Reporting bugs
 
@@ -260,7 +260,7 @@ azure group create <name> <location>
 Next we can either use our published template directly using `--template-uri`
 
 ```sh
-azure group deployment create --template-uri https://raw.githubusercontent.com/elastic/azure-marketplace/master/src/mainTemplate.json --parameters-file parameters/password.parameters.json -g name
+azure group deployment create --template-uri https://raw.githubusercontent.com/elastic/azure-marketplace/feature/5x-support/src/mainTemplate.json --parameters-file parameters/password.parameters.json -g name
 ```
 
 or if your are executing commands from a clone of this repo using `--template-file`
@@ -277,7 +277,7 @@ The `--parameters-file` can specify a different location for the items that get 
 
 ### Web based deploy
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fazure-marketplace%2Fmaster%2Fsrc%2FmainTemplate.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fazure-marketplace%2Ffeature/5x-support%2Fsrc%2FmainTemplate.json" target="_blank">
    <img alt="Deploy to Azure" src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 

--- a/build/allowedValues.json
+++ b/build/allowedValues.json
@@ -26,6 +26,12 @@
     },
     "2.4.1": {
       "kibana": "4.6.1"
+    },
+    "5.0.2": {
+      "kibana": "5.0.2"
+    },
+    "5.1.1": {
+      "kibana": "5.1.1"
     }
   },
   "locations" : [
@@ -34,7 +40,7 @@
     "centralus",
     "eastus",
     "eastus2",
-    "westus", 
+    "westus",
     "northcentralus",
     "southcentralus",
     "northeurope",

--- a/build/tasks/arm-test-deploy.js
+++ b/build/tasks/arm-test-deploy.js
@@ -1,0 +1,153 @@
+var config = require('../.test.json');
+var gulp = require("gulp");
+const execFile = require('child_process').execFile;
+var fs = require('fs');
+var _ = require('lodash');
+var dateFormat = require("dateformat");
+var git = require('git-rev')
+var merge = require('merge');
+var mkdirp = require('mkdirp');
+var del = require('del');
+var request = require('request');
+var hostname = require("os").hostname();
+var operatingSystem = require("os").platform();
+
+var azureCli = "../node_modules/.bin/azure";
+if (operatingSystem === "win32")
+  azureCli = "..\\node_modules\\.bin\\azure.cmd";
+
+var runDate = dateFormat(new Date(), "-yyyymmdd-HHMMss-Z").replace("+","-");
+var log = (data) => console.log(data);
+
+
+var bootstrapTest = (artifactsBaseUrl) =>
+{
+  var params = require("../../parameters/test.parameters.json");
+  params.artifactsBaseUrl.value = artifactsBaseUrl;
+  params.adminUsername.value = config.deployments.username;
+  params.adminPassword.value = config.deployments.password;
+  params.sshPublicKey.value = config.deployments.ssh;
+  params.shieldAdminPassword.value = config.deployments.shieldPassword;
+  params.shieldReadPassword.value = config.deployments.shieldPassword;
+  params.shieldKibanaPassword.value = config.deployments.shieldPassword;
+
+  return {
+    location: "westeurope",
+    resourceGroup: "test-" + hostname.toLowerCase() + "-" + "single" + dateFormat(new Date(), "-yyyymmdd-HHMMssl").replace("+","-"),
+    templateUri:  artifactsBaseUrl + "/mainTemplate.json",
+    params: params
+  }
+}
+
+var bootstrap = (cb) => {
+  git.branch(function (branch) {
+    var artifactsBaseUrl = "https://raw.githubusercontent.com/elastic/azure-marketplace/"+ branch + "/src";
+    var test = bootstrapTest(artifactsBaseUrl);
+    cb(test);
+  })
+};
+
+var login = (cb) => bootstrap((test) => {
+  var login = [ 'login', '--service-principal',
+    '--username', config.arm.clientId,
+    '--password', config.arm.clientSecret,
+    '--tenant', config.arm.tenantId
+  ];
+  log("logging into azure cli tooling")
+  var child = execFile(azureCli, login, (error, stdout, stderr) => {
+    if (error || stderr) return bailOut(error || new Error(stderr), true);
+    cb(test);
+  });
+});
+
+var logout = (cb) => {
+  var logout = [ 'logout', config.arm.clientId];
+  log("logging out of the  azure cli tooling")
+  execFile(azureCli, logout, cb);
+}
+
+var bailOut = (error)  => {
+  if (!error) return;
+  log(error)
+  logout(() => { throw error; });
+}
+
+var createResourceGroup = (test, cb) => {
+  var rg = test.resourceGroup;
+  var location = test.location;
+  var createGroup = [ 'group', 'create', rg, location, '--json'];
+  log("creating resource group: " + rg);
+  execFile(azureCli, createGroup, (error, stdout, stderr) => {
+    if (error || stderr) return bailOut(error || new Error(stderr));
+    log("createGroupResult: " + stdout);
+    var result = JSON.parse(stdout);
+    if (result.properties.provisioningState != "Succeeded") return bailOut(new Error("failed to create resourceGroup: " + rg));
+    cb();
+  });
+}
+
+var validateTemplate = (test, cb) => {
+  var p = JSON.stringify(test.params)
+  var rg = test.resourceGroup;
+  createResourceGroup(test, () => {
+    var validateGroup = [ 'group', 'template', 'validate',
+      '--resource-group', rg,
+      '--template-uri', test.templateUri,
+      '--parameters', p,
+      '--json'
+    ];
+    log("validating in resource group: " + rg);
+    execFile(azureCli, validateGroup, (error, stdout, stderr) => {
+      log("validateResult:" + !!(stdout || stderr));
+      if ((error || stderr)) return bailOut(error || new Error(stderr));
+      cb(test);
+    });
+  })
+}
+var showOperationList = (test, cb) => {
+  var rg = test.resourceGroup;
+  var operationList = [ 'group', 'deployment', 'operation', 'list',
+    rg,
+    'mainTemplate',
+    '--json'
+  ];
+  log("getting operation list result for deployment in resource group: " + rg);
+  execFile(azureCli, operationList, (error, stdout, stderr) => {
+    log("operationListResult:" + !!(stdout || stderr));
+    if (error || stderr) return bailOut(error || new Error(stderr));
+    var result = JSON.parse(stdout)
+    var errors = _(result)
+      .filter(f=>f.properties.provisioningState !== "Succeeded")
+      .map(f=>f.properties.statusMessage)
+      .value();
+    errors.forEach(e => {
+      log("resulted in error: " + JSON.stringify(e, null, 2));
+    })
+    console.error("deploment failed!")
+    cb();
+  });
+}
+
+var deployTemplate = (test, cb) => {
+  var p = JSON.stringify(test.params)
+  var rg = test.resourceGroup;
+  var deployGroup = [ 'group', 'deployment', 'create',
+    '--resource-group', rg,
+    '--template-uri', test.templateUri,
+    '--parameters', p,
+    '--quiet',
+    '--json'
+  ];
+  log("deploying in resource group: " + rg);
+  execFile(azureCli, deployGroup, (error, stdout, stderr) => {
+    log("deployResult: " + !!(stdout || stderr));
+    if (error || stderr) showOperationList(test, ()=> bailOut(error || new Error(stderr)));
+    else {
+      log("Succes! outputs: " + JSON.stringify(JSON.parse(stdout, null, 2).properties.outputs, null, 2))
+    }
+  });
+}
+
+gulp.task("deploy-test", function(cb) {
+  login((test) => validateTemplate(test, (test) => deployTemplate(test, () => logout(cb))));
+});

--- a/build/tasks/arm-validator.js
+++ b/build/tasks/arm-validator.js
@@ -11,6 +11,7 @@ var del = require('del');
 var request = require('request');
 var hostname = require("os").hostname();
 var operatingSystem = require("os").platform();
+var compareVersions = require('compare-versions');
 
 var azureCli = "../node_modules/.bin/azure";
 if (operatingSystem === "win32")
@@ -254,7 +255,8 @@ var sanityCheckExternalLoadBalancer = (test, url, cb) => {
   var t = armTests[test];
   var rg = t.resourceGroup;
   log("checking external loadbalancer "+ url +" in resource group: " + rg);
-  var opts = { json: true, auth: { username: "es_admin", password: config.deployments.shieldPassword } };
+  var superuser = compareVersions(t.params.esVersion.value,'5.0.0') >= 0 ? "elastic" : "es_admin";
+  var opts = { json: true, auth: { username: superuser, password: config.deployments.shieldPassword } };
   request(url, opts, (error, response, body) => {
     if (!error && response.statusCode == 200) {
       log(test, "loadBalancerResponse: " + JSON.stringify(body, null, 2));

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "headless": "gulp --gulpfile build/gulpfile.js headless",
     "azure-cleanup": "gulp --gulpfile build/gulpfile.js azure-cleanup",
     "deploy-all": "gulp --gulpfile build/gulpfile.js deploy-all",
+    "deploy-test": "gulp --gulpfile build/gulpfile.js deploy-test",
     "links": "gulp --gulpfile build/gulpfile.js links"
   },
   "repository": {
@@ -52,5 +53,8 @@
     "request": "^2.72.0",
     "requiredir": "^1.0.7",
     "yargs": "^6.0.0"
+  },
+  "dependencies": {
+    "compare-versions": "^3.0.0"
   }
 }

--- a/parameters/password.parameters.json
+++ b/parameters/password.parameters.json
@@ -1,5 +1,5 @@
 {
-	"artifactsBaseUrl":{"value":"https://raw.githubusercontent.com/elastic/azure-marketplace/master/src"},
+	"artifactsBaseUrl":{"value":"https://raw.githubusercontent.com/elastic/azure-marketplace/feature/5x-support/src"},
 	"esVersion":{"value":"2.2.0"},
 	"esClusterName":{"value":"my-azure-cluster"},
 	"location":{"value":"ResourceGroup"},
@@ -31,11 +31,11 @@
 	"vNetLoadBalancerIp": {"value": "10.0.0.4"},
     "vNetNewOrExisting": {"value":"new"},
     "vNetExistingResourceGroup": {"value": ""},
-    "vNetNewAddressPrefix": {"value": "10.0.0.0/16"},   
+    "vNetNewAddressPrefix": {"value": "10.0.0.0/16"},
     "vNetNewSubnetAddressPrefix": {"value": "10.0.0.0/24"},
 	"userCompany": { "value": "" },
 	"userEmail": { "value": "" },
-	"userFirstName": { "value": "" },	
+	"userFirstName": { "value": "" },
 	"userLastName": { "value": "" },
 	"userJobTitle": { "value": "" },
 	"userCountry": { "value": "" }

--- a/parameters/ssh.parameters.json
+++ b/parameters/ssh.parameters.json
@@ -1,5 +1,5 @@
 {
-	"artifactsBaseUrl":{"value":"https://raw.githubusercontent.com/elastic/azure-marketplace/master/src"},
+	"artifactsBaseUrl":{"value":"https://raw.githubusercontent.com/elastic/azure-marketplace/feature/5x-support/src"},
 	"esVersion":{"value":"2.2.0"},
 	"esClusterName":{"value":"my-azure-cluster"},
 	"location":{"value":"ResourceGroup"},

--- a/src/createUiDefinition.json
+++ b/src/createUiDefinition.json
@@ -53,7 +53,7 @@
             "name": "esVersion",
             "type": "Microsoft.Common.DropDown",
             "label": "Elasticsearch version",
-            "defaultValue": "v2.4.1",
+            "defaultValue": "v5.1.1",
             "toolTip": "Choose a version of Elasticsearch.",
             "constraints": {
               "allowedValues": [
@@ -92,6 +92,14 @@
                 {
                   "label": "v2.4.1",
                   "value": "2.4.1"
+                },
+                {
+                  "label": "v5.0.2",
+                  "value": "5.0.2"
+                },
+                {
+                  "label": "v5.1.1",
+                  "value": "5.1.1"
                 }
               ]
             }
@@ -613,7 +621,8 @@
           {
             "name": "es_admin",
             "type": "Microsoft.Common.Section",
-            "label": "es_admin User",
+            "label": "superuser account (es_admin for < 5.x elastic otherwise)",
+            "visible": "[greater(steps('nodesStep').clientNodes.vmClientNodeCount, 0)]",
             "elements": [
               {
                 "name": "shieldAdminPassword",

--- a/src/createUiDefinition.json
+++ b/src/createUiDefinition.json
@@ -622,7 +622,6 @@
             "name": "es_admin",
             "type": "Microsoft.Common.Section",
             "label": "superuser account (es_admin for < 5.x elastic otherwise)",
-            "visible": "[greater(steps('nodesStep').clientNodes.vmClientNodeCount, 0)]",
             "elements": [
               {
                 "name": "shieldAdminPassword",

--- a/src/createUiDefinition.json
+++ b/src/createUiDefinition.json
@@ -621,16 +621,16 @@
           {
             "name": "es_admin",
             "type": "Microsoft.Common.Section",
-            "label": "superuser account (es_admin for < 5.x elastic otherwise)",
+            "label": "Superuser Account ",
             "elements": [
               {
                 "name": "shieldAdminPassword",
                 "type": "Microsoft.Common.PasswordBox",
                 "label": {
-                  "password": "es_admin Password",
+                  "password": "(es_admin or elastic) password",
                   "confirmPassword": "Confirm password"
                 },
-                "toolTip": "Password to use for the es_admin Shield user.",
+                "toolTip": "Elasticsearch 5.x this is the password for the builtin `elastic` user otherwise we'll create a `es_admin` user",
                 "constraints": {
                   "required": true,
                   "regex": "^.{6,}",

--- a/src/createUiDefinition.json
+++ b/src/createUiDefinition.json
@@ -611,12 +611,12 @@
       },
       {
         "name": "shieldStep",
-        "label": "Shield Users Configuration",
+        "label": "User Configuration",
         "subLabel": {
           "preValidation": "Required",
           "postValidation": "Done"
         },
-        "bladeTitle": "Shield Users Configuration",
+        "bladeTitle": "User Configuration",
         "elements": [
           {
             "name": "es_admin",
@@ -634,7 +634,7 @@
                 "constraints": {
                   "required": true,
                   "regex": "^.{6,}",
-                  "validationMessage": "Shield password must be at least 6 characters long"
+                  "validationMessage": "Password must be at least 6 characters long"
                 },
                 "options": {
                   "hideConfirmation": false
@@ -654,11 +654,11 @@
                   "password": "es_read Password",
                   "confirmPassword": "Confirm password"
                 },
-                "toolTip": "Password to use for the es_read Shield user.",
+                "toolTip": "Password to use for the es_read user.",
                 "constraints": {
                   "required": true,
                   "regex": "^.{6,}",
-                  "validationMessage": "Shield password must be at least 6 characters long"
+                  "validationMessage": "Password must be at least 6 characters long"
                 },
                 "options": {
                   "hideConfirmation": false
@@ -678,11 +678,11 @@
                   "password": "es_kibana Password",
                   "confirmPassword": "Confirm password"
                 },
-                "toolTip": "Password to use for the es_kibana Shield user.",
+                "toolTip": "Password to use for the es_kibana user.",
                 "constraints": {
                   "required": true,
                   "regex": "^.{6,}",
-                  "validationMessage": "Shield password must be at least 6 characters long"
+                  "validationMessage": "Password must be at least 6 characters long"
                 },
                 "options": {
                   "hideConfirmation": false

--- a/src/machines/jumpbox-resources.json
+++ b/src/machines/jumpbox-resources.json
@@ -85,7 +85,7 @@
             "properties": {
               "description": "Allows SSH traffic",
               "protocol": "Tcp",
-              "sourcePortRange": "[parameters('osSettings').managementPort]",
+              "sourcePortRange": "*",
               "destinationPortRange": "[parameters('osSettings').managementPort]",
               "sourceAddressPrefix": "*",
               "destinationAddressPrefix": "*",

--- a/src/machines/kibana-resources.json
+++ b/src/machines/kibana-resources.json
@@ -91,7 +91,7 @@
             "properties": {
               "description": "Allows inbound SSH traffic from anyone",
               "protocol": "Tcp",
-              "sourcePortRange": "[parameters('osSettings').managementPort]",
+              "sourcePortRange": "*",
               "destinationPortRange": "[parameters('osSettings').managementPort]",
               "sourceAddressPrefix": "*",
               "destinationAddressPrefix": "*",
@@ -105,7 +105,7 @@
             "properties": {
               "description": "Allows inbound Kibana HTTP traffic from anyone",
               "protocol": "Tcp",
-              "sourcePortRange": "5601",
+              "sourcePortRange": "*",
               "destinationPortRange": "5601",
               "sourceAddressPrefix": "*",
               "destinationAddressPrefix": "*",

--- a/src/mainTemplate.json
+++ b/src/mainTemplate.json
@@ -4,14 +4,14 @@
   "parameters": {
     "artifactsBaseUrl": {
       "type": "string",
-      "defaultValue": "https://raw.githubusercontent.com/elastic/azure-marketplace/master/src",
+      "defaultValue": "https://raw.githubusercontent.com/elastic/azure-marketplace/feature/5x-support/src",
       "metadata": {
         "artifactsBaseUrl": "Base URL of the Elastic template gallery package"
       }
     },
     "esVersion": {
       "type": "string",
-      "defaultValue": "2.4.1",
+      "defaultValue": "5.1.1",
       "allowedValues": [
         "2.0.2",
         "2.1.2",
@@ -21,7 +21,9 @@
         "2.3.4",
         "2.3.5",
         "2.4.0",
-        "2.4.1"
+        "2.4.1",
+        "5.0.2",
+        "5.1.1"
       ],
       "metadata": {
         "description": "Elasticsearch version to install"
@@ -430,19 +432,19 @@
     "shieldAdminPassword": {
       "type": "securestring",
       "metadata": {
-        "description": "Shield password for the 'es_admin' user with admin role, must be > 6 characters"
+        "description": "Password for the superuser 'es_admin' in 2.x or 'elastic' in 5.x and up, must be > 6 characters"
       }
     },
     "shieldReadPassword": {
       "type": "securestring",
       "metadata": {
-        "description": "Shield password for the 'es_read' user with user (read-only) role, must be > 6 characters"
+        "description": "Password for the 'es_read' user with user (read-only) role, must be > 6 characters"
       }
     },
     "shieldKibanaPassword": {
       "type": "securestring",
       "metadata": {
-        "description": "Shield password for the `es_kibana` user with kibana4 role, must be > 6 characters"
+        "description": "Password for the `es_kibana` user with kibana4 role, must be > 6 characters"
       }
     },
     "location": {
@@ -637,7 +639,9 @@
       "2.3.4": "4.5.4",
       "2.3.5": "4.5.4",
       "2.4.0": "4.6.1",
-      "2.4.1": "4.6.1"
+      "2.4.1": "4.6.1",
+      "5.0.2": "5.0.2",
+      "5.1.1": "5.1.1"
     },
     "esSettings": {
       "clusterName": "[parameters('esClusterName')]",

--- a/src/scripts/data-node-install.sh
+++ b/src/scripts/data-node-install.sh
@@ -1,31 +1,11 @@
 #!/bin/bash
 
-# The MIT License (MIT)
-#
-# Portions Copyright (c) 2015 Microsoft Azure
-# Portions Copyright (c) 2015 Elastic, Inc.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# License: https://github.com/elastic/azure-marketplace/blob/master/LICENSE.txt
 #
 # Trent Swanson (Full Scale 180 Inc)
-# Martijn Laarman (Elastic)
-# Russ Cam (Elastic)
+# Martijn Laarman, Greg Marzouka, Russ Cam (Elastic)
+# Contributors
+#
 
 #########################
 # HELP

--- a/src/scripts/elasticsearch-ubuntu-install.sh
+++ b/src/scripts/elasticsearch-ubuntu-install.sh
@@ -363,7 +363,7 @@ apply_security_settings_2x()
             echo -e "        - manage"
             echo -e "        - read"
             echo -e "        - index"
-        } >> $1
+        } >> $SEC_FILE
         log "[install_plugins]  kibana4 role added"
     fi
     log "[install_plugins]  Finished checking roles.yml for kibana4 role"

--- a/src/scripts/elasticsearch-ubuntu-install.sh
+++ b/src/scripts/elasticsearch-ubuntu-install.sh
@@ -1,30 +1,10 @@
 #!/bin/bash
 
-# The MIT License (MIT)
-#
-# Portions Copyright (c) 2015 Microsoft Azure
-# Portions Copyright (c) 2015 Elastic, Inc.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# License: https://github.com/elastic/azure-marketplace/blob/master/LICENSE.txt
 #
 # Trent Swanson (Full Scale 180 Inc)
-# Martijn Laarman (Elastic)
+# Martijn Laarman, Greg Marzouka, Russ Cam (Elastic)
+# Contributors
 #
 
 #########################
@@ -59,8 +39,8 @@ help()
 
     echo "-h view this help content"
 }
-
-# log() does an echo prefixed with time
+# Custom logging with time so we can easily relate running times, also log to separate file so order is guaranteed.
+# The Script extension output the stdout/err buffer in intervals with duplicates.
 log()
 {
     echo \[$(date +%d%m%Y-%H:%M:%S)\] "$1"
@@ -97,7 +77,7 @@ else
 fi
 
 #########################
-# Paramater handling
+# Parameter handling
 #########################
 
 CLUSTER_NAME="elasticsearch"
@@ -247,8 +227,29 @@ install_java()
     echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections
     echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-selections
     log "[install_java] Installing Java"
-    (apt-get -yq install oracle-java8-installer || (sleep 15; apt-get -yq install oracle-java8-installer)) || (sudo rm /var/cache/oracle-jdk8-installer/jdk-*; sudo apt-get install)
-    log "[install_java] Installed Java"
+    (apt-get -yq install oracle-java8-installer || (sleep 15; apt-get -yq install oracle-java8-installer))
+    command -v java >/dev/null 2>&1 || { sleep 15; sudo rm /var/cache/oracle-jdk8-installer/jdk-*; sudo apt-get install -f; }
+
+    #if the previus did not install correctly we go nuclear, otherwise this loop will early exit
+    for i in $(seq 30); do
+      if $(command -v java >/dev/null 2>&1); then
+        log "[install_java] Installed java!"
+        return
+      else
+        sleep 5
+        sudo rm /var/cache/oracle-jdk8-installer/jdk-*;
+        sudo rm -f /var/lib/dpkg/info/oracle-java8-installer*
+        sudo rm /etc/apt/sources.list.d/*java*
+        sudo apt-get -yq purge oracle-java8-installer*
+        sudo apt-get -yq autoremove
+        sudo apt-get -yq clean
+        (add-apt-repository -y ppa:webupd8team/java || (sleep 15; add-apt-repository -y ppa:webupd8team/java))
+        sudo apt-get -yq update
+        sudo apt-get -yq install --reinstall oracle-java8-installer
+        log "[install_java] Seeing if java is Installed after nuclear retry ${i}/30"
+      fi
+    done
+    command -v java >/dev/null 2>&1 || { log "Java did not get installed properly even after a retry and a forced installation" >&2; exit 50; }
 }
 
 # Install Elasticsearch
@@ -256,6 +257,8 @@ install_es()
 {
     if [[ "${ES_VERSION}" == \2* ]]; then
         DOWNLOAD_URL="https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/$ES_VERSION/elasticsearch-$ES_VERSION.deb?ultron=msft&gambit=azure"
+    elif [[ "${ES_VERSION}" == \5* ]]; then
+        DOWNLOAD_URL="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ES_VERSION.deb?ultron=msft&gambit=azure"
     else
         DOWNLOAD_URL="https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-$ES_VERSION.deb"
     fi
@@ -271,30 +274,78 @@ install_es()
     sudo update-rc.d elasticsearch disable
 }
 
+## Plugins
+##----------------------------------
+
+plugin_cmd()
+{
+    if [[ "${ES_VERSION}" == \5* ]]; then
+      echo /usr/share/elasticsearch/bin/elasticsearch-plugin
+    else
+      echo /usr/share/elasticsearch/bin/plugin
+    fi
+}
+
 install_plugins()
 {
-    log "[install_plugins] Installing X-Pack plugins Shield, Marvel, Watcher"
-    sudo /usr/share/elasticsearch/bin/plugin install license
-    sudo /usr/share/elasticsearch/bin/plugin install shield
-    sudo /usr/share/elasticsearch/bin/plugin install watcher
-    sudo /usr/share/elasticsearch/bin/plugin install marvel-agent
-    log "[install_plugins] Installed X-Pack plugins Shield, Marvel, Watcher"
-    if dpkg --compare-versions "$ES_VERSION" ">=" "2.3.0"; then
-      log "[install_plugins] Installing X-Pack plugin Graph"
-      sudo /usr/share/elasticsearch/bin/plugin install graph
-      log "[install_plugins] Installed X-Pack plugin Graph"
+    if [[ "${ES_VERSION}" == \5* ]]; then
+      sudo $(plugin_cmd) install x-pack --batch
+    else
+      log "[install_plugins] Installing X-Pack plugins Shield, Marvel, Watcher"
+      sudo $(plugin_cmd) install license
+      sudo $(plugin_cmd) install shield
+      sudo $(plugin_cmd) install watcher
+      sudo $(plugin_cmd) install marvel-agent
+      if dpkg --compare-versions "$ES_VERSION" ">=" "2.3.0"; then
+        log "[install_plugins] Installing X-Pack plugin Graph"
+        sudo $(plugin_cmd) install graph
+        log "[install_plugins] Installed X-Pack plugin Graph"
+      fi
+      log "[install_plugins] Installed X-Pack plugins Shield, Marvel, Watcher"
     fi
 
-    log "[install_plugins] Start adding es_admin"
-    sudo /usr/share/elasticsearch/bin/shield/esusers useradd "es_admin" -p "${USER_ADMIN_PWD}" -r admin
-    log "[install_plugins] Finished adding es_admin"
+}
 
-    log "[install_plugins]  Start adding es_read"
-    sudo /usr/share/elasticsearch/bin/shield/esusers useradd "es_read" -p "${USER_READ_PWD}" -r user
-    log "[install_plugins]  Finished adding es_read"
+install_azure_cloud_plugin()
+{
+    log "[install_azure_cloud_plugin] Installing plugin Cloud-Azure"
+    sudo $(plugin_cmd) install cloud-azure
+    log "[install_azure_cloud_plugin] Installed plugin Cloud-Azure"
+}
 
-    log "[install_plugins]  Check that roles.yml contains kibana4 role"
-    if ! sudo grep -q "kibana4:" "/etc/elasticsearch/shield/roles.yml"; then
+install_additional_plugins()
+{
+    SKIP_PLUGINS="license shield watcher marvel-agent graph cloud-azure"
+    log "[install_additional_plugins] Installing additional plugins"
+    for PLUGIN in $(echo $INSTALL_ADDITIONAL_PLUGINS | tr ";" "\n")
+    do
+        if [[ $SKIP_PLUGINS =~ $PLUGIN ]]; then
+            log "[install_additional_plugins] Skipping plugin $PLUGIN"
+        else
+            log "[install_additional_plugins] Installing plugin $PLUGIN"
+            sudo $(plugin_cmd) install $PLUGIN
+            log "[install_additional_plugins] Installed plugin $PLUGIN"
+        fi
+    done
+}
+
+## Security
+##----------------------------------
+
+security_cmd()
+{
+    if [[ "${ES_VERSION}" == \5* ]]; then
+      echo /usr/share/elasticsearch/bin/x-pack/users
+    else
+      echo /usr/share/elasticsearch/bin/shield/esusers
+    fi
+}
+
+apply_security_settings_2x()
+{
+    local SEC_FILE=/etc/elasticsearch/shield/roles.yml
+    log "[install_plugins]  Check that $SEC_FILE contains kibana4 role"
+    if ! sudo grep -q "kibana4:" "$SEC_FILE"; then
         log "[install_plugins]  No kibana4 role. Adding now"
         {
             echo -e ""
@@ -312,42 +363,141 @@ install_plugins()
             echo -e "        - manage"
             echo -e "        - read"
             echo -e "        - index"
-        } >> /etc/elasticsearch/shield/roles.yml
+        } >> $1
         log "[install_plugins]  kibana4 role added"
     fi
     log "[install_plugins]  Finished checking roles.yml for kibana4 role"
 
+    log "[install_plugins] Start adding es_admin"
+    sudo $(security_cmd) useradd "es_admin" -p "${USER_ADMIN_PWD}" -r admin
+    log "[install_plugins] Finished adding es_admin"
+
+    log "[install_plugins]  Start adding es_read"
+    sudo $(security_cmd) useradd "es_read" -p "${USER_READ_PWD}" -r user
+    log "[install_plugins]  Finished adding es_read"
+
     log "[install_plugins]  Start adding es_kibana"
-    sudo /usr/share/elasticsearch/bin/shield/esusers useradd "es_kibana" -p "${USER_KIBANA4_PWD}" -r kibana4
-    log "[install_plugins]  Finished adding es_kibina"
+    sudo $(security_cmd) useradd "es_kibana" -p "${USER_KIBANA4_PWD}" -r kibana4
+    log "[install_plugins]  Finished adding es_kibana"
 
     log "[install_plugins]  Start adding es_kibana_server"
-    sudo /usr/share/elasticsearch/bin/shield/esusers useradd "es_kibana_server" -p "${USER_KIBANA4_SERVER_PWD}" -r kibana4_server
+    sudo $(security_cmd) useradd "es_kibana_server" -p "${USER_KIBANA4_SERVER_PWD}" -r kibana4_server
     log "[install_plugins]  Finished adding es_kibana_server"
 }
 
-install_azure_cloud_plugin()
+node_is_up()
 {
-    log "[install_azure_cloud_plugin] Installing plugin Cloud-Azure"
-    sudo /usr/share/elasticsearch/bin/plugin install cloud-azure
-    log "[install_azure_cloud_plugin] Installed plugin Cloud-Azure"
+  curl --output /dev/null --silent --head --fail http://localhost:9200 --user elastic:$1
+  return $?
+}
+wait_for_started()
+{
+  for i in $(seq 30); do
+    if $(node_is_up "changeme" || node_is_up "$USER_ADMIN_PWD"); then
+      log "[wait_for_started] Node is up!"
+      return
+    else
+      sleep 5
+      log "[wait_for_started] Seeing if node is up for the after sleeping 5 seconds, retry ${i}/30"
+    fi
+  done
+  log "[wait_for_started] never saw elasticsearch go up locally"
+  exit 10
 }
 
-install_additional_plugins()
-{
-    SKIP_PLUGINS="license shield watcher marvel-agent graph cloud-azure"
-    log "[install_additional_plugins] Installing additional plugins"
-    for PLUGIN in $(echo $INSTALL_ADDITIONAL_PLUGINS | tr ";" "\n")
-    do
-        if [[ $SKIP_PLUGINS =~ $PLUGIN ]]; then
-            log "[install_additional_plugins] Skipping plugin $PLUGIN"
-        else
-            log "[install_additional_plugins] Installing plugin $PLUGIN"
-            sudo /usr/share/elasticsearch/bin/plugin install $PLUGIN
-            log "[install_additional_plugins] Installed plugin $PLUGIN"
-        fi
-    done
+#since upserts of roles users CAN throw 409 conflicts we ignore these for now
+#opened a tick on x-pack repos to handle this more gracefully later
+curl_ignore_409 () {
+    _curl_with_error_code "$@" | sed '$d'
 }
+_curl_with_error_code () {
+    local curl_error_code http_code
+    exec 17>&1
+    http_code=$(curl --write-out '\n%{http_code}\n' "$@" | tee /dev/fd/17 | tail -n 1)
+    curl_error_code=$?
+    exec 17>&-
+    if [ $http_code -eq 409 ]; then
+      return 0
+    fi
+    if [ $curl_error_code -ne 0 ]; then
+        return $curl_error_code
+    fi
+    if [ $http_code -ge 400 ] && [ $http_code -lt 600 ]; then
+        echo "HTTP $http_code" >&2
+        return 127
+    fi
+}
+
+apply_security_settings()
+{
+    if node_is_up "$USER_ADMIN_PWD"; then
+      log "[apply_security_settings] Can already ping node using user provided credentials, exiting early!"
+    else
+      log "[apply_security_settings] start updating roles and users"
+
+      #update superuser `elastic` this takes the role of `es_admin` in 2.x clusters
+      local ADMIN_JSON=$(printf '{"password": "%s"}\n' $USER_ADMIN_PWD)
+      echo $ADMIN_JSON | curl_ignore_409 -XPUT -u elastic:changeme 'localhost:9200/_xpack/security/user/elastic/_password' -d @-
+      if [[ $? != 0 ]]; then
+        #Make sure another deploy did not already change the elastic password
+        curl_ignore_409 -XGET -u elastic:$USER_ADMIN_PWD  'localhost:9200/'
+        if [[ $? != 0 ]]; then
+          log "[apply_security_settings] could not update the builtin elastic user"
+          exit 10
+        fi
+      fi
+      log "[apply_security_settings] updated builtin elastic superuser password"
+
+      #update builtin `kibana` server account
+      local KIBANA_JSON=$(printf '{"password": "%s"}\n' $USER_KIBANA4_SERVER_PWD)
+      echo $KIBANA_JSON | curl_ignore_409 -XPUT -u elastic:$USER_ADMIN_PWD 'localhost:9200/_xpack/security/user/kibana/_password' -d @-
+      if [[ $? != 0 ]];  then
+        log "[apply_security_settings] could not update the builtin kibana user"
+        exit 10
+      fi
+      log "[apply_security_settings] updated builtin kibana user password"
+
+      # add `es_kibana` user with the new builtin [kibana_user, monitoring_user, reporting_user] roles
+      local KIBANA_USER_JSON=$(printf '{"password": "%s", "roles":["kibana_user", "monitoring_user", "reporting_user"]}\n' $USER_KIBANA4_PWD)
+      echo $KIBANA_USER_JSON | curl_ignore_409 -XPOST -u elastic:$USER_ADMIN_PWD 'localhost:9200/_xpack/security/user/es_kibana?pretty' -d @-
+      if [[ $? != 0 ]]; then
+        log "[apply_security_settings] could not add es_kibana"
+        exit 10
+      fi
+      log "[apply_security_settings] added es_kibana account"
+
+      #create a readonly role that mimmics the `user` role in shield for `es_read`
+      curl_ignore_409 -XPOST -u elastic:$USER_ADMIN_PWD 'localhost:9200/_xpack/security/role/user?pretty' -d'
+      {
+        "cluster": [ "monitor" ],
+        "indices": [
+          {
+            "names": [ "*" ],
+            "privileges": [ "read", "monitor", "view_index_metadata" ]
+          }
+        ]
+      }'
+      if [[ $? != 0 ]]; then
+        log "[apply_security_settings] could not create user role"
+        exit 10
+      fi
+      log "[apply_security_settings] added user role"
+
+      # add `es_read` user with the newly created `user` role
+      local USER_JSON=$(printf '{"password": "%s", "roles":["user"]}\n' $USER_READ_PWD)
+      echo $USER_JSON | curl_ignore_409 -XPOST -u elastic:$USER_ADMIN_PWD 'localhost:9200/_xpack/security/user/es_read?pretty' -d @-
+      if [[ $? != 0 ]]; then
+        log "[apply_security_settings] could not add es_read"
+        exit 10
+      fi
+      log "[apply_security_settings] added es_read account"
+
+      log "[apply_security_settings] updated roles and users"
+    fi
+}
+
+## Configuration
+##----------------------------------
 
 configure_elasticsearch_yaml()
 {
@@ -363,7 +513,6 @@ configure_elasticsearch_yaml()
 
     # Configure discovery
     log "[configure_elasticsearch_yaml] Update configuration with hosts configuration of $UNICAST_HOSTS"
-    echo "discovery.zen.ping.multicast.enabled: false" >> /etc/elasticsearch/elasticsearch.yml
     echo "discovery.zen.ping.unicast.hosts: $UNICAST_HOSTS" >> /etc/elasticsearch/elasticsearch.yml
 
     # Configure Elasticsearch node type
@@ -391,9 +540,15 @@ configure_elasticsearch_yaml()
     fi
 
     echo "discovery.zen.minimum_master_nodes: $MINIMUM_MASTER_NODES" >> /etc/elasticsearch/elasticsearch.yml
-    echo "network.host: _non_loopback_" >> /etc/elasticsearch/elasticsearch.yml
 
-    echo "marvel.agent.enabled: true" >> /etc/elasticsearch/elasticsearch.yml
+    if [[ "${ES_VERSION}" == \5* ]]; then
+        echo "network.host: [_site_, _local_]" >> /etc/elasticsearch/elasticsearch.yml
+    else
+        echo "discovery.zen.ping.multicast.enabled: false" >> /etc/elasticsearch/elasticsearch.yml
+        echo "network.host: _non_loopback_" >> /etc/elasticsearch/elasticsearch.yml
+        echo "marvel.agent.enabled: true" >> /etc/elasticsearch/elasticsearch.yml
+    fi
+
     echo "node.max_local_storage_nodes: 1" >> /etc/elasticsearch/elasticsearch.yml
 
     # Configure Azure Cloud plugin
@@ -406,6 +561,60 @@ configure_elasticsearch_yaml()
     # Swap is disabled by default in Ubuntu Azure VMs
     # echo "bootstrap.mlockall: true" >> /etc/elasticsearch/elasticsearch.yml
 }
+
+configure_elasticsearch()
+{
+    log "[configure_elasticsearch] configuring elasticsearch default configuration"
+    local ES_HEAP=`free -m |grep Mem | awk '{if ($2/2 >31744)  print 31744;else print $2/2;}'`
+    if [[ "${ES_VERSION}" == \5* ]]; then
+      configure_elasticsearch5 $ES_HEAP
+    else
+      configure_elasticsearch2 $ES_HEAP
+    fi
+    log "[configure_elasticsearch] configured elasticsearch default configuration"
+}
+configure_elasticsearch2()
+{
+    log "[configure_elasticsearch] Configure elasticsearch 2.x heap size - $1"
+    echo "ES_HEAP_SIZE=$1m" >> /etc/default/elasticsearch
+
+    # Allow dots in field names in 2.4.0+
+    if dpkg --compare-versions "$ES_VERSION" ">=" "2.4.0"; then
+      log "[configure_elasticsearch] Configure allow dots in field names"
+      echo "ES_JAVA_OPTS=-Dmapper.allow_dots_in_name=true" >> /etc/default/elasticsearch
+    fi
+}
+
+configure_elasticsearch5()
+{
+    log "[configure_elasticsearch] Configure elasticsearch 5.x heap size - $1"
+    echo "-Xmx$1m" >> /etc/elasticsearch/jvm.options
+    echo "-Xms$1m" >> /etc/elasticsearch/jvm.options
+}
+
+configure_os_properties()
+{
+    log "[configure_os_properties] configuring operating system level configuration"
+    # DNS Retry
+    echo "options timeout:10 attempts:5" >> /etc/resolvconf/resolv.conf.d/head
+    resolvconf -u
+
+    # Increase maximum mmap count
+    echo "vm.max_map_count = 262144" >> /etc/sysctl.conf
+
+    # Verify this is necessary on azure
+    # ML: 80% certain i verified this but will do so again
+    #echo "elasticsearch    -    nofile    65536" >> /etc/security/limits.conf
+    #echo "elasticsearch     -    memlock   unlimited" >> /etc/security/limits.conf
+    #echo "session    required    pam_limits.so" >> /etc/pam.d/su
+    #echo "session    required    pam_limits.so" >> /etc/pam.d/common-session
+    #echo "session    required    pam_limits.so" >> /etc/pam.d/common-session-noninteractive
+    #echo "session    required    pam_limits.so" >> /etc/pam.d/sudo
+    log "[configure_os_properties] configured operating system level configuration"
+}
+
+## Installation of dependencies
+##----------------------------------
 
 install_ntp()
 {
@@ -438,43 +647,6 @@ start_monit()
     sudo monit reload # use the new configuration
     sudo monit start all
     log "[start_monit] started monit"
-}
-
-configure_elasticsearch()
-{
-    log "[configure_elasticsearch] configuring elasticsearch default configuration"
-    #TODO: Move this to an init.d script so we can handle instance size increases
-    ES_HEAP=`free -m |grep Mem | awk '{if ($2/2 >31744)  print 31744;else print $2/2;}'`
-    log "[configure_elasticsearch] Configure elasticsearch heap size - $ES_HEAP"
-    echo "ES_HEAP_SIZE=${ES_HEAP}m" >> /etc/default/elasticsearch
-
-    # Allow dots in field names in 2.4.0+
-    if dpkg --compare-versions "$ES_VERSION" ">=" "2.4.0"; then
-      log "[configure_elasticsearch] Configure allow dots in field names"
-      echo "ES_JAVA_OPTS=-Dmapper.allow_dots_in_name=true" >> /etc/default/elasticsearch
-    fi
-    log "[configure_elasticsearch] configured elasticsearch default configuration"
-}
-
-configure_os_properties()
-{
-    log "[configure_os_properties] configuring operating system level configuration"
-    # DNS Retry
-    echo "options timeout:10 attempts:5" >> /etc/resolvconf/resolv.conf.d/head
-    resolvconf -u
-
-    # Increase maximum mmap count
-    echo "vm.max_map_count = 262144" >> /etc/sysctl.conf
-
-    # Verify this is necessary on azure
-    # ML: 80% certain i verified this but will do so again
-    #echo "elasticsearch    -    nofile    65536" >> /etc/security/limits.conf
-    #echo "elasticsearch     -    memlock   unlimited" >> /etc/security/limits.conf
-    #echo "session    required    pam_limits.so" >> /etc/pam.d/su
-    #echo "session    required    pam_limits.so" >> /etc/pam.d/common-session
-    #echo "session    required    pam_limits.so" >> /etc/pam.d/common-session-noninteractive
-    #echo "session    required    pam_limits.so" >> /etc/pam.d/sudo
-    log "[configure_os_properties] configured operating system level configuration"
 }
 
 port_forward()
@@ -527,6 +699,10 @@ setup_data_disk
 
 if [ ${INSTALL_PLUGINS} -ne 0 ]; then
     install_plugins
+    # in 2.x we use the file realm so we can apply security config before boot up
+    if [[ "${ES_VERSION}" == \2* ]]; then
+        apply_security_settings_2x
+    fi
 fi
 
 if [[ ! -z "${INSTALL_ADDITIONAL_PLUGINS// }" ]]; then
@@ -548,6 +724,14 @@ configure_os_properties
 start_monit
 
 port_forward
+
+# In 5.x we have to patch roles and users through the REST API which is a tad trickier
+if [ ${INSTALL_PLUGINS} -ne 0 ]; then
+    if [[ "${ES_VERSION}" == \5* ]]; then
+        wait_for_started
+        apply_security_settings
+    fi
+fi
 
 ELAPSED_TIME=$(($SECONDS - $START_TIME))
 PRETTY=$(printf '%dh:%dm:%ds\n' $(($ELAPSED_TIME/3600)) $(($ELAPSED_TIME%3600/60)) $(($ELAPSED_TIME%60)))

--- a/src/scripts/kibana-install.sh
+++ b/src/scripts/kibana-install.sh
@@ -1,31 +1,10 @@
 #!/bin/bash
 
-# The MIT License (MIT)
-#
-# Portions Copyright (c) 2015 Microsoft Azure
-# Portions Copyright (c) 2015 Elastic, Inc.
-#
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# License: https://github.com/elastic/azure-marketplace/blob/master/LICENSE.txt
 #
 # Trent Swanson (Full Scale 180 Inc)
-# Martijn Laarman (Elastic)
+# Martijn Laarman, Greg Marzouka, Russ Cam (Elastic)
+# Contributors
 #
 
 #########################
@@ -47,7 +26,8 @@ help()
     echo "-h view this help content"
 }
 
-# log() does an echo prefixed with time
+# Custom logging with time so we can easily relate running times, also log to separate file so order is guaranteed.
+# The Script extension output the stdout/err buffer in intervals with duplicates.
 log()
 {
     echo \[$(date +%d%m%Y-%H:%M:%S)\] "$1"
@@ -65,7 +45,7 @@ if service --status-all | grep -Fq 'kibana'; then
 fi
 
 #########################
-# Paramater handling
+# Parameter handling
 #########################
 
 #Script Parameters
@@ -76,7 +56,6 @@ ES_VERSION="2.0.0"
 ELASTICSEARCH_URL="http://10.0.0.4:9200"
 INSTALL_PLUGINS=0
 HOSTMODE="internal"
-
 USER_KIBANA4_SERVER_PWD="changeME"
 
 #Loop through options passed
@@ -125,106 +104,199 @@ log "installing kibana plugins is set to: $INSTALL_PLUGINS"
 log "Kibana will talk to elasticsearch over $ELASTICSEARCH_URL"
 
 #########################
-# Installation
+# Installation steps as functions
 #########################
 
-sudo groupadd -g 999 kibana
-sudo useradd -u 999 -g 999 kibana
+old_add_kibana_os_user()
+{
+  log "[old_add_kibana_os_user] adding kibana user"
+  sudo groupadd -g 999 kibana
+  sudo useradd -u 999 -g 999 kibana
+}
 
-sudo mkdir -p /opt/kibana
+old_download_unzip_kibana()
+{
+  sudo mkdir -p /opt/kibana
+  if dpkg --compare-versions "$KIBANA_VERSION" ">=" "5.0.0"; then
+      DOWNLOAD_URL="https://artifacts.elastic.co/downloads/kibana/kibana-$KIBANA_VERSION-linux-x86_64.tar.gz"
+  elif dpkg --compare-versions "$KIBANA_VERSION" ">=" "4.6.0"; then
+      DOWNLOAD_URL="https://download.elastic.co/kibana/kibana/kibana-$KIBANA_VERSION-linux-x86_64.tar.gz"
+  else
+      DOWNLOAD_URL="https://download.elastic.co/kibana/kibana/kibana-$KIBANA_VERSION-linux-x64.tar.gz"
+  fi
 
-if dpkg --compare-versions "$KIBANA_VERSION" ">=" "4.6.0"; then
-    DOWNLOAD_URL="https://download.elastic.co/kibana/kibana/kibana-$KIBANA_VERSION-linux-x86_64.tar.gz"
-else
-    DOWNLOAD_URL="https://download.elastic.co/kibana/kibana/kibana-$KIBANA_VERSION-linux-x64.tar.gz"
-fi
+  log "[old_download_unzip_kibana] downloading kibana $KIBANA_VERSION from $DOWNLOAD_URL"
+  curl -o kibana.tar.gz "$DOWNLOAD_URL"
+  tar xvf kibana.tar.gz -C /opt/kibana/ --strip-components=1
+  log "kibana $KIBANA_VERSION downloaded"
 
-log "downloading kibana $KIBANA_VERSION from $DOWNLOAD_URL"
-curl -o kibana.tar.gz "$DOWNLOAD_URL"
-tar xvf kibana.tar.gz -C /opt/kibana/ --strip-components=1
-log "kibana $KIBANA_VERSION downloaded"
+  sudo chown -R kibana: /opt/kibana
 
-sudo chown -R kibana: /opt/kibana
+  mv /opt/kibana/config/kibana.yml /opt/kibana/config/kibana.yml.bak
+}
 
-mv /opt/kibana/config/kibana.yml /opt/kibana/config/kibana.yml.bak
+download_install_deb()
+{
+    log "[download_install_deb] starting download of package"
+    local DOWNLOAD_URL="https://artifacts.elastic.co/downloads/kibana/kibana-$KIBANA_VERSION-amd64.deb"
+    curl -o "kibana-$KIBANA_VERSION.deb" "$DOWNLOAD_URL"
+    log "[download_install_deb] installing downloaded package"
+    sudo dpkg -i "kibana-$KIBANA_VERSION.deb"
+}
 
-# set the elasticsearch URL
-echo "elasticsearch.url: \"$ELASTICSEARCH_URL\"" >> /opt/kibana/config/kibana.yml
-# specify kibana log location
-echo "logging.dest: /var/log/kibana.log" >> /opt/kibana/config/kibana.yml
+## Security
+##----------------------------------
 
-if [ ${INSTALL_PLUGINS} -ne 0 ]; then
+old_configuration_and_plugins()
+{
+    log "[old_configuration_and_plugins] configuring kibana.yml"
+    # set the elasticsearch URL
+    echo "elasticsearch.url: \"$ELASTICSEARCH_URL\"" >> /opt/kibana/config/kibana.yml
+    # specify kibana log location
+    echo "logging.dest: /var/log/kibana.log" >> /opt/kibana/config/kibana.yml
     echo "elasticsearch.username: es_kibana_server" >> /opt/kibana/config/kibana.yml
     echo "elasticsearch.password: \"$USER_KIBANA4_SERVER_PWD\"" >> /opt/kibana/config/kibana.yml
 
     # install shield only on Elasticsearch 2.4.0+ so that graph can be used.
-    # cannot be installed on earlier versions as 
+    # cannot be installed on earlier versions as
     # they do not allow unsafe sessions (i.e. sending session cookie over HTTP)
     if dpkg --compare-versions "$ES_VERSION" ">=" "2.4.0"; then
-      log "installing latest shield"
+      log "[old_configuration_and_plugins] installing latest shield"
       /opt/kibana/bin/kibana plugin --install kibana/shield/2.4.0
-      log "shield plugin installed"
+      log "[old_configuration_and_plugins] shield plugin installed"
 
-      # NOTE: These settings allow Shield to work in Kibana without HTTPS. 
+      # NOTE: These settings allow Shield to work in Kibana without HTTPS.
       # This is NOT recommended for production.
       echo "shield.useUnsafeSessions: true" >> /opt/kibana/config/kibana.yml
       echo "shield.skipSslCheck: true" >> /opt/kibana/config/kibana.yml
 
-      log "generating shield encryption key"
-      if [ $(dpkg-query -W -f='${Status}' pwgen 2>/dev/null | grep -c "ok installed") -eq 0 ]; then
-        (sudo apt-get -yq install pwgen || (sleep 15; sudo apt-get -yq install pwgen))
-      fi
-      ENCRYPTION_KEY=$(pwgen 64 1)    
+      install_pwgen
+
+      log "[old_configuration_and_plugins] generating shield encryption key"
+      ENCRYPTION_KEY=$(pwgen 64 1)
       echo "shield.encryptionKey: \"$ENCRYPTION_KEY\"" >> /opt/kibana/config/kibana.yml
-      log "shield encryption key generated"    
+      log "[old_configuration_and_plugins] shield encryption key generated"
     fi
 
     # install graph
     if dpkg --compare-versions "$ES_VERSION" ">=" "2.3.0"; then
-      log "installing graph plugin"
+      log "[old_configuration_and_plugins] installing graph plugin"
       /opt/kibana/bin/kibana plugin --install elasticsearch/graph/$ES_VERSION
-      log "graph plugin installed"
+      log "[old_configuration_and_plugins] graph plugin installed"
     fi
 
     # install reporting
     if dpkg --compare-versions "$KIBANA_VERSION" ">=" "4.6.1"; then
-      log "installing reporting plugin"
+      log "[old_configuration_and_plugins] installing reporting plugin"
       /opt/kibana/bin/kibana plugin --install kibana/reporting/2.4.1
-      log "reporting plugin installed"
+      log "[old_configuration_and_plugins] reporting plugin installed"
 
-      log "generating reporting encryption key"
+      log "[old_configuration_and_plugins] generating reporting encryption key"
       if [ $(dpkg-query -W -f='${Status}' pwgen 2>/dev/null | grep -c "ok installed") -eq 0 ]; then
         (sudo apt-get -yq install pwgen || (sleep 15; sudo apt-get -yq install pwgen))
       fi
-      ENCRYPTION_KEY=$(pwgen 64 1)    
+      ENCRYPTION_KEY=$(pwgen 64 1)
       echo "reporting.encryptionKey: \"$ENCRYPTION_KEY\"" >> /opt/kibana/config/kibana.yml
-      log "reporting encryption key generated"    
+      log "[old_configuration_and_plugins] reporting encryption key generated"
     fi
 
-    log "installing monitoring plugin"
+    log "[old_configuration_and_plugins] installing monitoring plugin"
     /opt/kibana/bin/kibana plugin --install elasticsearch/marvel/$ES_VERSION
-    log "monitoring plugin installed"
-    log "installing sense plugin"
+    log "[old_configuration_and_plugins] monitoring plugin installed"
+    log "[old_configuration_and_plugins] installing sense plugin"
     /opt/kibana/bin/kibana plugin --install elastic/sense
-    log "sense plugin installed"
+    log "[old_configuration_and_plugins] sense plugin installed"
 
     # sense default url to point at Elasticsearch on first load
     echo "sense.defaultServerUrl: \"$ELASTICSEARCH_URL\"" >> /opt/kibana/config/kibana.yml
+}
+
+install_pwgen()
+{
+    log "[install_pwgen] installing pwgen tool if needed"
+    if [ $(dpkg-query -W -f='${Status}' pwgen 2>/dev/null | grep -c "ok installed") -eq 0 ]; then
+      (sudo apt-get -yq install pwgen || (sleep 15; sudo apt-get -yq install pwgen))
+    fi
+}
+
+configuration_and_plugins()
+{
+    log "[configuration_and_plugins] configuring kibana.yml"
+    local KIBANA_CONF=/etc/kibana/kibana.yml
+    # set the elasticsearch URL
+    echo "elasticsearch.url: \"$ELASTICSEARCH_URL\"" >> $KIBANA_CONF
+    echo "elasticsearch.username: kibana" >> $KIBANA_CONF
+    echo "elasticsearch.password: $USER_KIBANA4_SERVER_PWD" >> $KIBANA_CONF
+    echo "server.host:" $(hostname -I) >> $KIBANA_CONF
+
+    local ENCRYPTION_KEY=$(pwgen 64 1)
+    echo "xpack.security.encryptionKey: \"$ENCRYPTION_KEY\"" >> $KIBANA_CONF
+    echo "xpack.reporting.encryptionKey: \"$ENCRYPTION_KEY\"" >> $KIBANA_CONF
+    log "[configuration_and_plugins] x-pack security encryption key generated"
+
+    log "[configuration_and_plugins] installing xpack plugin"
+    sudo /usr/share/kibana/bin/kibana-plugin install x-pack
+    log "[configuration_and_plugins] installed xpack plugin"
+}
+
+old_install_service()
+{
+    log "[old_install_service] configuring makeshift service for kibana 4"
+    {
+      echo -e "# kibana"
+      echo -e "description \"Elasticsearch Kibana Service\""
+      echo -e ""
+      echo -e "start on starting"
+      echo -e "script"
+      echo -e "  /opt/kibana/bin/kibana"
+      echo -e "end script"
+      echo -e ""
+    } >> /etc/init/kibana.conf
+
+    chmod +x /etc/init/kibana.conf
+    sudo service kibana start
+}
+
+install_start_service()
+{
+    log "[install_start_service] configuring service for kibana to run at start"
+    sudo update-rc.d kibana defaults 95 10
+    log "[install_start_service] starting kibana!"
+    sudo service kibana start
+}
+
+old_install_sequence()
+{
+    log "[old_install_sequence] Starting the old install sequence for kibana"
+    sudo service kibana start
+    old_add_kibana_os_user
+    old_download_unzip_kibana
+    old_configuration_and_plugins
+    old_install_service
+    log "[old_install_sequence] Finished installation"
+}
+
+install_sequence()
+{
+    log "[install_sequence] Starting installation"
+    download_install_deb
+    install_pwgen
+    configuration_and_plugins
+    install_start_service
+    log "[install_sequence] Finished installation"
+}
+
+#########################
+# Installation sequence
+#########################
+
+if [ ${INSTALL_PLUGINS} -ne 0 ]; then
+  if dpkg --compare-versions "$KIBANA_VERSION" ">=" "5.0.0"; then
+    install_sequence
+  else
+    old_install_sequence
+  fi
 fi
-
-# Add upstart task and start kibana service
-cat << EOF > /etc/init/kibana.conf
-# kibana
-description "Elasticsearch Kibana Service"
-
-start on starting
-script
-    /opt/kibana/bin/kibana
-end script
-EOF
-
-chmod +x /etc/init/kibana.conf
-sudo service kibana start
 
 ELAPSED_TIME=$(($SECONDS - $START_TIME))
 PRETTY=$(printf '%dh:%dm:%ds\n' $(($ELAPSED_TIME/3600)) $(($ELAPSED_TIME%3600/60)) $(($ELAPSED_TIME%60)))

--- a/src/scripts/kibana-install.sh
+++ b/src/scripts/kibana-install.sh
@@ -268,7 +268,6 @@ install_start_service()
 old_install_sequence()
 {
     log "[old_install_sequence] Starting the old install sequence for kibana"
-    sudo service kibana start
     old_add_kibana_os_user
     old_download_unzip_kibana
     old_configuration_and_plugins


### PR DESCRIPTION
This adds supports for Elasticsearch & Kibana 5.x

Elasticsearch installation:

- improved java installation even further by going nuclear on retry routine cleaning after apt get completely before retrying. Was still seeing random checksum failures quite often
- XPack security is now all native (REST API) based, no longer based on the file realm
- Because we do upserts we need to ignore 409 on curl commands
- Added a wait for online method that waits until elasticsearch is started before firing off REST calls. Could be useful for different things in the future too.
- `es_admin` no longer exists in 5.x we update the builtin `elastic` superuser instead.

Kibana Installation

- Moved to the debian package for installation
- Debian package takes care of setting up service and file based logging
- make sure we set server.host to external ip since kibana 5.x no longer binds to 0.0.0.0 by default (rightfully so!)

ARM Template (jumpbox & kibana)

- `sourcePortRange` needs to be `*` in order for 5601 and 22 to be accessible now that we apply NSG correctly

UI
- mention the different superuser usernames in the label

Build

- add `npm run deploy-test` which quickly deploys any `test.parameters.json` file (gitignored) to `westeurope` to ease development
- `npm run deploy-all` now validates using a variable superuser username based on what version we are testing.