### PR TITLE
Fix Artifacts Base Url

### DIFF
--- a/src/mainTemplate.json
+++ b/src/mainTemplate.json
@@ -4,7 +4,7 @@
   "parameters": {
     "artifactsBaseUrl": {
       "type": "string",
-      "defaultValue": "https://raw.githubusercontent.com/elastic/azure-marketplace/feature/5x-support/src",
+      "defaultValue": "https://raw.githubusercontent.com/elastic/azure-marketplace/master/src",
       "metadata": {
         "artifactsBaseUrl": "Base URL of the Elastic template gallery package"
       }


### PR DESCRIPTION
The artifacts base url for the 5x feature branch no longer exists. I've changed it to the master branch.