### PR TITLE
Fix azure cloud plugin name

### DIFF
--- a/src/scripts/elasticsearch-ubuntu-install.sh
+++ b/src/scripts/elasticsearch-ubuntu-install.sh
@@ -309,7 +309,7 @@ install_plugins()
 install_azure_cloud_plugin()
 {
     log "[install_azure_cloud_plugin] Installing plugin Cloud-Azure"
-    sudo $(plugin_cmd) install cloud-azure
+    sudo $(plugin_cmd) install repository-azure
     log "[install_azure_cloud_plugin] Installed plugin Cloud-Azure"
 }
 


### PR DESCRIPTION
The cloud-azure plugin no longer exists. It's been replaced with the repository-azure plugin.

https://www.elastic.co/guide/en/elasticsearch/plugins/current/repository-azure.html