### PR TITLE
Support Ubuntu 16.04 for Elasticsearch 5.x+

### DIFF
--- a/src/scripts/elasticsearch-ubuntu-install.sh
+++ b/src/scripts/elasticsearch-ubuntu-install.sh
@@ -569,7 +569,7 @@ configure_elasticsearch_yaml()
 configure_elasticsearch()
 {
     log "[configure_elasticsearch] configuring elasticsearch default configuration"
-    local ES_HEAP=`free -m |grep Mem | awk '{if ($2/2 >31744)  print 31744;else print $2/2;}'`
+    local ES_HEAP=`free -m |grep Mem | awk '{if ($2/2 >31744)  print 31744;else print int($2/2+0.5);}'`
     if [[ "${ES_VERSION}" == \5* ]]; then
       configure_elasticsearch5 $ES_HEAP
     else

--- a/src/settings/ubuntuSettings.json
+++ b/src/settings/ubuntuSettings.json
@@ -78,11 +78,16 @@
       "[concat(parameters('templateBaseUrl'), 'scripts/data-node-install.sh')]"
     ],
     "clientInstallScript": "[concat('bash elasticsearch-ubuntu-install.sh -y', variables('commonShortOpts'), variables('commonInstallParams'))]",
+    "ubuntuSkus": {
+      "2": "14.04.4-LTS",
+      "5": "16.04.0-LTS"
+    },
+    "ubuntuSku": "[variables('ubuntuSkus')[substring(parameters('esSettings').version, 0, 1)]]",
     "ubuntuSettings": {
       "imageReference": {
         "publisher": "Canonical",
         "offer": "UbuntuServer",
-        "sku": "14.04.4-LTS",
+        "sku": "[variables('ubuntuSku')]",
         "version": "latest"
       },
       "managementPort": "22",


### PR DESCRIPTION
Round calculation up to nearest Mb when calculating heap size as half of available memory.

Closes #80