### PR TITLE
Lower address space for VNet and Subnet

### DIFF
--- a/src/createUiDefinition.json
+++ b/src/createUiDefinition.json
@@ -138,10 +138,10 @@
                 },
                 "defaultValue": {
                   "name": "es-net",
-                  "addressPrefixSize": "/16"
+                  "addressPrefixSize": "/24"
                 },
                 "constraints": {
-                  "minAddressPrefixSize": "/16"
+                  "minAddressPrefixSize": "/24"
                 },
                 "options": {
                   "hideExisting": false
@@ -151,11 +151,11 @@
                     "label": "subnet",
                     "defaultValue": {
                       "name": "es-subnet",
-                      "addressPrefixSize": "/24"
+                      "addressPrefixSize": "/25"
                     },
                     "constraints": {
-                      "minAddressPrefixSize": "/24",
-                      "minAddressCount": 12,
+                      "minAddressPrefixSize": "/25",
+                      "minAddressCount": 3,
                       "requireContiguousAddresses": true
                     }
                   }

--- a/src/mainTemplate.json
+++ b/src/mainTemplate.json
@@ -565,14 +565,14 @@
     },
     "vNetNewAddressPrefix": {
       "type": "string",
-      "defaultValue": "10.0.0.0/16",
+      "defaultValue": "10.0.0.0/24",
       "metadata": {
         "description": "The address prefix size to use for a New Virtual Network. Required when creating a new Virtual Network"
       }
     },
     "vNetNewSubnetAddressPrefix": {
       "type": "string",
-      "defaultValue": "10.0.0.0/24",
+      "defaultValue": "10.0.0.0/25",
       "metadata": {
         "description": "The address space of the subnet. Required when creating a new Virtual Network"
       }


### PR DESCRIPTION
Lower VNet to /24 = 254 usable IP addresses
Lower Subnet to /25 = 126 usable IP addresses
Lower Minimum address count to 3 - smallest deployable cluster (1 data node, internal LB, Kibana/external LB)

Address spaces apply to both new and existing Virtual Networks in the Marketplace UI.

These should be adequate for the largest of deployments from the Marketplace; the ARM template is not limited to these address spaces and can specify whatever is required.

Closes #78