### PR TITLE
Use systemd for configuring Elasticsearch and Kibana

### DIFF
--- a/docs/azure-arm-template.asciidoc
+++ b/docs/azure-arm-template.asciidoc
@@ -28,7 +28,7 @@
 :applicationmanifest: {microsoftdocs}/azure/active-directory/develop/active-directory-application-manifest
 :owasp30: https://www.owasp.org/index.php/Category:OWASP_ModSecurity_Core_Rule_Set_Project
 :jq: https://stedolan.github.io/jq/
-:monit: https://mmonit.com/monit
+:systemd: https://www.freedesktop.org/wiki/Software/systemd/
 :version: 6.3.1
 :yamllint: http://www.yamllint.com/
 :openssl: https://www.openssl.org/docs/man1.0.2/apps/openssl.html
@@ -317,24 +317,22 @@ support to increase the limit for a VM SKU in a specific location.
 --
 
 Currently, the ARM template deploys _only_ to Ubuntu 16.04-LTS VMs, using images
-published to the Azure VM gallery by Canonical, and the {elasticdocs}/deb.html[Debian package distribution of Elasticsearch]. The template uses {monit}[monit] to manage and monitor the Elasticsearch process, with monit configured to run in daemon mode, checking
-the state of the Elasticsearch process every 30 seconds. If the process is found to not be running, monit will attempt to start the process.
+published to the Azure VM gallery by Canonical, and the {elasticdocs}/deb.html[Debian package distribution of Elasticsearch]. The template uses {systemd}[systemd] to run the Elasticsearch process, with Elasticsearch configured
+to start automatically when the system boots up.
 
-Elasticsearch can be stopped with monit <<azure-arm-template-troubleshooting-accessing-nodes, on an Elasticsearch VM node>> using
+Elasticsearch can be stopped with systemd <<azure-arm-template-troubleshooting-accessing-nodes, on an Elasticsearch VM node>> using
 
 [source,sh]
 ----
-sudo monit stop elasticsearch
+sudo systemctl stop elasticsearch.service
 ----
 
 and started with
 
 [source,sh]
 ----
-sudo monit start elasticsearch
+sudo systemctl start elasticsearch.service
 ----
-
-Refer to {monit}/documentation/monit.html[monit documentation] for further details.
 
 [[azure-arm-template-admin-username]]
 ==== Virtual machine admin username

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -45,7 +45,12 @@ example, the elasticsearch configuration file
 [source,sh]
 ----
 sudo su
+
+# check Elasticsearch configuration
 cat /etc/elasticsearch/elasticsearch.yml
+
+# check status of Elasticsearch service
+systemctl status elasticsearch.service
 ----
 
 [[azure-arm-template-troubleshooting-azure]]
@@ -110,10 +115,6 @@ A log file that contains log messages written to standard error (stderr) by the 
 `/var/lib/waagent/custom-script/download/0/stdout`::
 A log file that contains log messages written to standard output (stdout) by the Azure infrastructure when the Elasticsearch deployment script runs. There will be
 duplication of messages that have been written to `/var/log/arm-install.log`, in addition to other tooling related output such as apt package installations.
-
-`/var/log/monit.log`::
-A log file for {monit}[monit], the utility used to manage and monitor the
-Elasticsearch process. This log file is useful to check to ensure monit is running correctly.
 
 [[azure-arm-template-troubleshooting-elasticsearch-logs]]
 ==== Elasticsearch logs

--- a/src/scripts/elasticsearch-install.sh
+++ b/src/scripts/elasticsearch-install.sh
@@ -30,7 +30,7 @@ help()
     echo "    -R      read password"
     echo "    -K      kibana user password"
     echo "    -S      logstash_system user password"
-	echo "    -F      beats_system user password"
+    echo "    -F      beats_system user password"
 
     echo "    -x      configure as a dedicated master node"
     echo "    -y      configure as client only node (no master, no data)"
@@ -57,6 +57,7 @@ help()
 
     echo "    -h      view this help content"
 }
+
 # Custom logging with time so we can easily relate running times, also log to separate file so order is guaranteed.
 # The Script extension output the stdout/err buffer in intervals with duplicates.
 log()

--- a/src/scripts/elasticsearch-install.sh
+++ b/src/scripts/elasticsearch-install.sh
@@ -1118,19 +1118,18 @@ configure_os_properties()
 
     # Required for bootstrap memory lock
     #echo "MAX_LOCKED_MEMORY=unlimited" >> /etc/default/elasticsearch
-
+    local SYSTEMD_OVERRIDES=/etc/systemd/system/elasticsearch.service.d
+    [ -d $SYSTEMD_OVERRIDES ] || mkdir -p $SYSTEMD_OVERRIDES
     {
       echo "[Service]"
       echo "LimitMEMLOCK=infinity"
-    } >> /etc/systemd/system/elasticsearch.service.d/override.conf
+    } >> $SYSTEMD_OVERRIDES/override.conf
 
     # Maximum number of open files for elasticsearch user
     echo "elasticsearch - nofile 65536" >> /etc/security/limits.conf
 
     # Ubuntu ignores the limits.conf file for processes started by init.d by default, so enable them
     echo "session    required   pam_limits.so" >> /etc/pam.d/su
-
-
 
     log "[configure_os_properties] configure systemd to start Elasticsearch service automatically when system boots"
     systemctl daemon-reload

--- a/src/scripts/elasticsearch-install.sh
+++ b/src/scripts/elasticsearch-install.sh
@@ -16,45 +16,46 @@ export DEBIAN_FRONTEND=noninteractive
 help()
 {
     echo "This script installs Elasticsearch cluster on Ubuntu"
-    echo "Parameters:"
-    echo "-n elasticsearch cluster name"
-    echo "-v elasticsearch version e.g. 6.2.2"
-    echo "-p hostname prefix of nodes for unicast discovery"
-    echo "-m heap size in megabytes to allocate to JVM"
+    echo ""
+    echo "Options:"
+    echo "    -n      elasticsearch cluster name"
+    echo "    -v      elasticsearch version e.g. 6.4.1"
+    echo "    -p      hostname prefix of nodes for unicast discovery"
+    echo "    -m      heap size in megabytes to allocate to JVM"
 
-    echo "-d cluster uses dedicated masters"
-    echo "-Z <number of nodes> hint to the install script how many data nodes we are provisioning"
+    echo "    -d      cluster uses dedicated masters"
+    echo "    -Z      <number of nodes> hint to the install script how many data nodes we are provisioning"
 
-    echo "-A admin password"
-    echo "-R read password"
-    echo "-K kibana user password"
-    echo "-S logstash_system user password"
-    echo "-F beats_system user password"
+    echo "    -A      admin password"
+    echo "    -R      read password"
+    echo "    -K      kibana user password"
+    echo "    -S      logstash_system user password"
+	echo "    -F      beats_system user password"
 
-    echo "-x configure as a dedicated master node"
-    echo "-y configure as client only node (no master, no data)"
-    echo "-z configure as data node (no master)"
-    echo "-l install plugins"
-    echo "-L <plugin;plugin> install additional plugins"
-    echo "-C <yaml\nyaml> additional yaml configuration"
+    echo "    -x      configure as a dedicated master node"
+    echo "    -y      configure as client only node (no master, no data)"
+    echo "    -z      configure as data node (no master)"
+    echo "    -l      install X-Pack plugin (<6.3.0) or apply trial license for Platinum features (6.3.0+)"
+    echo "    -L      <plugin;plugin> install additional plugins"
+    echo "    -C      <yaml\nyaml> additional yaml configuration"
 
-    echo "-H base64 encoded PKCS#12 archive (.p12/.pfx) containing the key and certificate used to secure the HTTP layer"
-    echo "-G password for PKCS#12 archive (.p12/.pfx) containing the key and certificate used to secure the HTTP layer"
-    echo "-V base64 encoded PKCS#12 archive (.p12/.pfx) containing the CA key and certificate used to secure the HTTP layer"
-    echo "-J password for PKCS#12 archive (.p12/.pfx) containing the CA key and certificate used to secure the HTTP layer"
+    echo "    -H      base64 encoded PKCS#12 archive (.p12/.pfx) containing the key and certificate used to secure the HTTP layer"
+    echo "    -G      password for PKCS#12 archive (.p12/.pfx) containing the key and certificate used to secure the HTTP layer"
+    echo "    -V      base64 encoded PKCS#12 archive (.p12/.pfx) containing the CA key and certificate used to secure the HTTP layer"
+    echo "    -J      password for PKCS#12 archive (.p12/.pfx) containing the CA key and certificate used to secure the HTTP layer"
 
-    echo "-T base64 encoded PKCS#12 archive (.p12/.pfx) containing the CA key and certificate used to secure the transport layer"
-    echo "-W password for PKCS#12 archive (.p12/.pfx) containing the CA key and certificate used to secure the transport layer"
-    echo "-N password for the generated PKCS#12 archive used to secure the transport layer"
+    echo "    -T      base64 encoded PKCS#12 archive (.p12/.pfx) containing the CA key and certificate used to secure the transport layer"
+    echo "    -W      password for PKCS#12 archive (.p12/.pfx) containing the CA key and certificate used to secure the transport layer"
+    echo "    -N      password for the generated PKCS#12 archive used to secure the transport layer"
 
-    echo "-O URI from which to retrieve the metadata file for the Identity Provider to configure SAML Single-Sign-On"
-    echo "-P Public domain name for the instance of Kibana to configure SAML Single-Sign-On"
+    echo "    -O      URI from which to retrieve the metadata file for the Identity Provider to configure SAML Single-Sign-On"
+    echo "    -P      Public domain name for the instance of Kibana to configure SAML Single-Sign-On"
 
-    echo "-j install azure cloud plugin for snapshot and restore"
-    echo "-a set the default storage account for azure cloud plugin"
-    echo "-k set the key for the default storage account for azure cloud plugin"
+    echo "    -j      install azure cloud plugin for snapshot and restore"
+    echo "    -a      set the default storage account for azure cloud plugin"
+    echo "    -k      set the key for the default storage account for azure cloud plugin"
 
-    echo "-h view this help content"
+    echo "    -h      view this help content"
 }
 # Custom logging with time so we can easily relate running times, also log to separate file so order is guaranteed.
 # The Script extension output the stdout/err buffer in intervals with duplicates.
@@ -97,7 +98,7 @@ fi
 
 CLUSTER_NAME="elasticsearch"
 NAMESPACE_PREFIX=""
-ES_VERSION="6.4.0"
+ES_VERSION="6.4.1"
 ES_HEAP=0
 INSTALL_XPACK=0
 INSTALL_ADDITIONAL_PLUGINS=""
@@ -1207,7 +1208,7 @@ if systemctl -q is-active elasticsearch.service; then
   check_data_disk
 
   # restart elasticsearch if the configuration has changed
-  cmp --silent /etc/elasticsearch/elasticsearch.yml /etc/elasticsearch/elasticsearch.bak \
+  cmp --silent /etc/elasticsearch/elasticsearch.yml /etc/elasticsearch/elasticsearch.yml.bak \
     || systemctl reload-or-restart elasticsearch.service
 
   exit 0

--- a/src/scripts/elasticsearch-install.sh
+++ b/src/scripts/elasticsearch-install.sh
@@ -1108,28 +1108,13 @@ configure_os_properties()
     echo "options timeout:10 attempts:5" >> /etc/resolvconf/resolv.conf.d/head
     resolvconf -u
 
-    # Increase maximum mmap count
-    echo "vm.max_map_count = 262144" >> /etc/sysctl.conf
-
-    # Update pam_limits for bootstrap memory lock
-    echo "# allow user 'elasticsearch' mlockall" >> /etc/security/limits.conf
-    echo "elasticsearch soft memlock unlimited" >> /etc/security/limits.conf
-    echo "elasticsearch hard memlock unlimited" >> /etc/security/limits.conf
-
-    # Required for bootstrap memory lock
-    #echo "MAX_LOCKED_MEMORY=unlimited" >> /etc/default/elasticsearch
+    # Required for bootstrap memory lock with systemd
     local SYSTEMD_OVERRIDES=/etc/systemd/system/elasticsearch.service.d
     [ -d $SYSTEMD_OVERRIDES ] || mkdir -p $SYSTEMD_OVERRIDES
     {
       echo "[Service]"
       echo "LimitMEMLOCK=infinity"
     } >> $SYSTEMD_OVERRIDES/override.conf
-
-    # Maximum number of open files for elasticsearch user
-    echo "elasticsearch - nofile 65536" >> /etc/security/limits.conf
-
-    # Ubuntu ignores the limits.conf file for processes started by init.d by default, so enable them
-    echo "session    required   pam_limits.so" >> /etc/pam.d/su
 
     log "[configure_os_properties] configure systemd to start Elasticsearch service automatically when system boots"
     systemctl daemon-reload

--- a/src/scripts/kibana-install.sh
+++ b/src/scripts/kibana-install.sh
@@ -19,9 +19,9 @@ help()
     echo ""
     echo "Options:"
     echo "    -n      elasticsearch cluster name"
-    echo "    -v      kibana version e.g 6.2.2"
+    echo "    -v      kibana version e.g 6.4.1"
     echo "    -u      elasticsearch url e.g. http://10.0.0.4:9200"
-    echo "    -l      install plugins true/false"
+    echo "    -l      install X-Pack plugin (<6.3.0) or apply trial license for Platinum features (6.3.0+)"
     echo "    -S      kibana password"
     echo "    -C      kibana cert to encrypt communication between the browser and Kibana"
     echo "    -K      kibana key to encrypt communication between the browser and Kibana"
@@ -57,18 +57,13 @@ then
     exit 3
 fi
 
-if service --status-all | grep -Fq 'kibana'; then
-  log "Kibana already installed."
-  exit 0
-fi
-
 #########################
 # Parameter handling
 #########################
 
 #Script Parameters
 CLUSTER_NAME="elasticsearch"
-KIBANA_VERSION="6.4.0"
+KIBANA_VERSION="6.4.1"
 #Default internal load balancer ip
 ELASTICSEARCH_URL="http://10.0.0.4:9200"
 INSTALL_XPACK=0
@@ -153,20 +148,38 @@ log "Kibana will talk to Elasticsearch over $ELASTICSEARCH_URL"
 # Installation steps as functions
 #########################
 
-download_kibana()
+install_kibana()
 {
-    log "[download_kibana] Download Kibana $KIBANA_VERSION"
-    local DOWNLOAD_URL="https://artifacts.elastic.co/downloads/kibana/kibana-$KIBANA_VERSION-amd64.deb?ultron=msft&gambit=azure"
-    log "[download_kibana] Download location $DOWNLOAD_URL"
-    wget --retry-connrefused --waitretry=1 -q "$DOWNLOAD_URL" -O "kibana-$KIBANA_VERSION.deb"
+    local PACKAGE="kibana-$KIBANA_VERSION-amd64.deb"
+    local SHASUM="$PACKAGE.sha512"
+    local DOWNLOAD_URL="https://artifacts.elastic.co/downloads/kibana/$PACKAGE?ultron=msft&gambit=azure"
+    local SHASUM_URL="https://artifacts.elastic.co/downloads/kibana/$SHASUM?ultron=msft&gambit=azure"
+
+    log "[install_kibana] download Kibana $KIBANA_VERSION"
+    wget --retry-connrefused --waitretry=1 -q "$SHASUM_URL" -O $SHASUM
     local EXIT_CODE=$?
     if [ $EXIT_CODE -ne 0 ]; then
-        log "[download_kibana] Error downloading Kibana $KIBANA_VERSION"
+        log "[install_kibana] error downloading Kibana $KIBANA_VERSION checksum"
         exit $EXIT_CODE
     fi
-    log "[download_kibana] Installing Kibana $KIBANA_VERSION"
-    dpkg -i "kibana-$KIBANA_VERSION.deb"
-    log "[download_kibana] Installed Kibana $KIBANA_VERSION"
+    log "[install_kibana] download location $DOWNLOAD_URL"
+    wget --retry-connrefused --waitretry=1 -q "$DOWNLOAD_URL" -O "kibana-$KIBANA_VERSION.deb"
+    EXIT_CODE=$?
+    if [ $EXIT_CODE -ne 0 ]; then
+        log "[install_kibana] error downloading Kibana $KIBANA_VERSION"
+        exit $EXIT_CODE
+    fi
+    log "[install_kibana] downloaded Kibana $KIBANA_VERSION"
+    shasum -a 512 -c $SHASUM
+    EXIT_CODE=$?
+    if [ $EXIT_CODE -ne 0 ]; then
+        log "[install_kibana] error validating checksum for Kibana $KIBANA_VERSION"
+        exit $EXIT_CODE
+    fi
+
+    log "[install_kibana] installing Kibana $KIBANA_VERSION"
+    dpkg -i $PACKAGE
+    log "[install_kibana] installed Kibana $KIBANA_VERSION"
 }
 
 ## Security
@@ -180,14 +193,14 @@ install_pwgen()
     fi
 }
 
-configuration_and_plugins()
+configure_kibana_yaml()
 {
     local KIBANA_CONF=/etc/kibana/kibana.yml
     local SSL_PATH=/etc/kibana/ssl
     # backup the current config
     mv $KIBANA_CONF $KIBANA_CONF.bak
 
-    log "[configuration_and_plugins] Configuring kibana.yml"
+    log "[configure_kibana_yaml] Configuring kibana.yml"
 
     # set the elasticsearch URL
     echo "elasticsearch.url: \"$ELASTICSEARCH_URL\"" >> $KIBANA_CONF
@@ -208,32 +221,32 @@ configuration_and_plugins()
       install_pwgen
       local ENCRYPTION_KEY=$(pwgen 64 1)
       echo "xpack.security.encryptionKey: \"$ENCRYPTION_KEY\"" >> $KIBANA_CONF
-      log "[configuration_and_plugins] X-Pack security encryption key generated"
+      log "[configure_kibana_yaml] X-Pack Security encryption key generated"
       ENCRYPTION_KEY=$(pwgen 64 1)
       echo "xpack.reporting.encryptionKey: \"$ENCRYPTION_KEY\"" >> $KIBANA_CONF
-      log "[configuration_and_plugins] X-Pack reporting encryption key generated"
+      log "[configure_kibana_yaml] X-Pack Reporting encryption key generated"
 
-      log "[configuration_and_plugins] installing X-Pack plugin"
+      log "[configure_kibana_yaml] Installing X-Pack plugin"
       /usr/share/kibana/bin/kibana-plugin install x-pack
-      log "[configuration_and_plugins] installed X-Pack plugin"
+      log "[configure_kibana_yaml] Installed X-Pack plugin"
     fi
 
     # configure HTTPS if cert and private key supplied
     if [[ -n "${SSL_CERT}" && -n "${SSL_KEY}" ]]; then
       [ -d $SSL_PATH ] || mkdir -p $SSL_PATH
-      log "[configuration_and_plugins] save kibana cert to file"
+      log "[configure_kibana_yaml] Save kibana cert to file"
       echo ${SSL_CERT} | base64 -d | tee $SSL_PATH/kibana.crt
-      log "[configuration_and_plugins] save kibana key to file"
+      log "[configure_kibana_yaml] Save kibana key to file"
       echo ${SSL_KEY} | base64 -d | tee $SSL_PATH/kibana.key
 
-      log "[configuration_and_plugins] configuring SSL/TLS to Kibana"
+      log "[configure_kibana_yaml] Configuring SSL/TLS to Kibana"
       echo "server.ssl.enabled: true" >> $KIBANA_CONF
       echo "server.ssl.key: $SSL_PATH/kibana.key" >> $KIBANA_CONF
       echo "server.ssl.certificate: $SSL_PATH/kibana.crt" >> $KIBANA_CONF
       if [[ -n "${SSL_PASSPHRASE}" ]]; then
           echo "server.ssl.keyPassphrase: \"$SSL_PASSPHRASE\"" >> $KIBANA_CONF
       fi
-      log "[configuration_and_plugins] configured SSL/TLS to Kibana"
+      log "[configure_kibana_yaml] Configured SSL/TLS to Kibana"
     fi
 
     # configure HTTPS communication with Elasticsearch if cert supplied and x-pack installed.
@@ -243,17 +256,17 @@ configuration_and_plugins()
 
       if [[ -n "${HTTP_CERT}" ]]; then
         # convert PKCS#12 certificate to PEM format
-        log "[configuration_and_plugins] save PKCS#12 archive for Elasticsearch HTTP to file"
+        log "[configure_kibana_yaml] Save PKCS#12 archive for Elasticsearch HTTP to file"
         echo ${HTTP_CERT} | base64 -d | tee $SSL_PATH/elasticsearch-http.p12
-        log "[configuration_and_plugins] extract CA cert from PKCS#12 archive for Elasticsearch HTTP"
+        log "[configure_kibana_yaml] Extract CA cert from PKCS#12 archive for Elasticsearch HTTP"
         echo "$HTTP_CERT_PASSWORD" | openssl pkcs12 -in $SSL_PATH/elasticsearch-http.p12 -out $SSL_PATH/elasticsearch-http-ca.crt -cacerts -nokeys -chain -passin stdin
 
-        log "[configuration_and_plugins] configuring TLS for Elasticsearch"
+        log "[configure_kibana_yaml] Configuring TLS for Elasticsearch"
         if [[ $(stat -c %s $SSL_PATH/elasticsearch-http-ca.crt 2>/dev/null) -eq 0 ]]; then
-            log "[configuration_and_plugins] no CA cert extracted from HTTP cert. Setting verification mode to none"
+            log "[configure_kibana_yaml] No CA cert extracted from HTTP cert. Setting verification mode to none"
             echo "elasticsearch.ssl.verificationMode: none" >> $KIBANA_CONF
         else
-            log "[configuration_and_plugins] CA cert extracted from HTTP PKCS#12 archive. Setting verification mode to certificate"
+            log "[configure_kibana_yaml] CA cert extracted from HTTP PKCS#12 archive. Setting verification mode to certificate"
             echo "elasticsearch.ssl.verificationMode: certificate" >> $KIBANA_CONF
             echo "elasticsearch.ssl.certificateAuthorities: [ $SSL_PATH/elasticsearch-http-ca.crt ]" >> $KIBANA_CONF
         fi
@@ -262,29 +275,29 @@ configuration_and_plugins()
 
         # convert PKCS#12 CA certificate to PEM format
         local HTTP_CACERT_FILENAME=elasticsearch-http-ca.p12
-        log "[configuration_and_plugins] save PKCS#12 archive for Elasticsearch HTTP CA to file"
+        log "[configure_kibana_yaml] Save PKCS#12 archive for Elasticsearch HTTP CA to file"
         echo ${HTTP_CACERT} | base64 -d | tee $SSL_PATH/$HTTP_CACERT_FILENAME
-        log "[configuration_and_plugins] convert PKCS#12 archive for Elasticsearch HTTP CA to PEM format"
+        log "[configure_kibana_yaml] Convert PKCS#12 archive for Elasticsearch HTTP CA to PEM format"
         echo "$HTTP_CACERT_PASSWORD" | openssl pkcs12 -in $SSL_PATH/$HTTP_CACERT_FILENAME -out $SSL_PATH/elasticsearch-http-ca.crt -clcerts -nokeys -chain -passin stdin
 
-        log "[configuration_and_plugins] configuring TLS for Elasticsearch"
+        log "[configure_kibana_yaml] Configuring TLS for Elasticsearch"
         if [[ $(stat -c %s $SSL_PATH/elasticsearch-http-ca.crt 2>/dev/null) -eq 0 ]]; then
-            log "[configuration_and_plugins] no CA cert extracted from HTTP CA. Setting verification mode to none"
+            log "[configure_kibana_yaml] No CA cert extracted from HTTP CA. Setting verification mode to none"
             echo "elasticsearch.ssl.verificationMode: none" >> $KIBANA_CONF
         else
-            log "[configuration_and_plugins] CA cert extracted from HTTP CA PKCS#12 archive. Setting verification mode to full"
+            log "[configure_kibana_yaml] CA cert extracted from HTTP CA PKCS#12 archive. Setting verification mode to full"
             echo "elasticsearch.ssl.verificationMode: full" >> $KIBANA_CONF
-            log "[configuration_and_plugins] set CA cert in certificate authorities"
+            log "[configure_kibana_yaml] Set CA cert in certificate authorities"
             echo "elasticsearch.ssl.certificateAuthorities: [ $SSL_PATH/elasticsearch-http-ca.crt ]" >> $KIBANA_CONF
         fi
       fi
       chown -R kibana: $SSL_PATH
-      log "[configuration_and_plugins] configured TLS for Elasticsearch"
+      log "[configure_kibana_yaml] Configured TLS for Elasticsearch"
     fi
 
     # Configure SAML Single-Sign-On
     if [[ -n "$SAML_SP_URI" && ${INSTALL_XPACK} -ne 0 ]]; then
-      log "[configuration_and_plugins] configuring Kibana for SAML Single-Sign-On"
+      log "[configure_kibana_yaml] Configuring Kibana for SAML Single-Sign-On"
       # Allow both saml and basic realms
       echo "xpack.security.authProviders: [ saml,basic ]" >> $KIBANA_CONF
       echo "server.xsrf.whitelist: [ /api/security/v1/saml ]" >> $KIBANA_CONF
@@ -306,12 +319,12 @@ configuration_and_plugins()
       echo "xpack.security.public.protocol: ${PROTOCOL%://}" >> $KIBANA_CONF
       echo "xpack.security.public.hostname: \"${HOSTNAME%/}\"" >> $KIBANA_CONF
       echo "xpack.security.public.port: ${PORT%/}" >> $KIBANA_CONF
-      log "[configuration_and_plugins] configured Kibana for SAML Single-Sign-On"
+      log "[configure_kibana_yaml] Configured Kibana for SAML Single-Sign-On"
     fi
 
     # Additional yaml configuration
     if [[ -n "$YAML_CONFIGURATION" ]]; then
-        log "[configuration_and_plugins] include additional yaml configuration"
+        log "[configure_kibana_yaml] include additional yaml configuration"
         local SKIP_LINES="elasticsearch.username elasticsearch.password "
         SKIP_LINES+="server.ssl.key server.ssl.cert server.ssl.enabled "
         SKIP_LINES+="xpack.security.encryptionKey xpack.reporting.encryptionKey "
@@ -325,22 +338,22 @@ configuration_and_plugins()
         for LINE in $(echo -e "$YAML_CONFIGURATION"); do
           if [[ -n "$LINE" ]]; then
               if [[ $LINE =~ $SKIP_REGEX ]]; then
-                  log "[configuration_and_plugins] skipping line '$LINE'"
+                  log "[configure_kibana_yaml] Skipping line '$LINE'"
               else
-                  log "[configuration_and_plugins] adding line '$LINE' to $KIBANA_CONF"
+                  log "[configure_kibana_yaml] Adding line '$LINE' to $KIBANA_CONF"
                   echo "$LINE" >> $KIBANA_CONF
               fi
           fi
         done
         unset IFS
-        log "[configuration_and_plugins] included additional yaml configuration"
-        log "[configuration_and_plugins] run yaml lint on configuration"
+        log "[configure_kibana_yaml] included additional yaml configuration"
+        log "[configure_kibana_yaml] run yaml lint on configuration"
         install_yamllint
         LINT=$(yamllint -d "{extends: relaxed, rules: {key-duplicates: {level: error}}}" $KIBANA_CONF; exit ${PIPESTATUS[0]})
         EXIT_CODE=$?
-        log "[configuration_and_plugins] ran yaml lint (exit code $EXIT_CODE) $LINT"
+        log "[configure_kibana_yaml] ran yaml lint (exit code $EXIT_CODE) $LINT"
         if [ $EXIT_CODE -ne 0 ]; then
-            log "[configuration_and_plugins] errors in yaml configuration. exiting"
+            log "[configure_kibana_yaml] errors in yaml configuration. exiting"
             exit 11
         fi
     fi
@@ -353,27 +366,48 @@ install_yamllint()
     log "[install_yamllint] installed yamllint"
 }
 
-install_start_service()
+configure_systemd()
 {
-    log "[install_start_service] configuring service for kibana to run at start"
-    update-rc.d kibana defaults 95 10
-    log "[install_start_service] starting Kibana!"
-    service kibana start
+    log "[configure_systemd] configure systemd to start Kibana service automatically when system boots"
+    systemctl daemon-reload
+    systemctl enable kibana.service
+}
+
+start_systemd()
+{
+    log "[start_systemd] starting Kibana"
+    systemctl start kibana.service
+    log "[start_systemd] started Kibana"
 }
 
 #########################
 # Installation sequence
 #########################
 
+# if kibana is already installed assume this is a redeploy
+# change yaml configuration and only restart the server when needed
+if systemctl -q is-active kibana.service; then
+
+  configure_kibana_yaml
+
+  # restart kibana if the configuration has changed
+  cmp --silent /etc/kibana/kibana.yml /etc/kibana/kibana.yml.bak \
+    || systemctl reload-or-restart kibana.service
+
+  exit 0
+fi
+
 log "[apt-get] updating apt-get"
 (apt-get -y update || (sleep 15; apt-get -y update)) > /dev/null
 log "[apt-get] updated apt-get"
 
-log "[install_sequence] starting installation"
-download_kibana
-configuration_and_plugins
-install_start_service
-log "[install_sequence] finished installation"
+install_kibana
+
+configure_kibana_yaml
+
+configure_systemd
+
+start_systemd
 
 ELAPSED_TIME=$(($SECONDS - $START_TIME))
 PRETTY=$(printf '%dh:%dm:%ds\n' $(($ELAPSED_TIME/3600)) $(($ELAPSED_TIME%3600/60)) $(($ELAPSED_TIME%60)))

--- a/src/scripts/kibana-install.sh
+++ b/src/scripts/kibana-install.sh
@@ -163,7 +163,7 @@ install_kibana()
         exit $EXIT_CODE
     fi
     log "[install_kibana] download location $DOWNLOAD_URL"
-    wget --retry-connrefused --waitretry=1 -q "$DOWNLOAD_URL" -O "kibana-$KIBANA_VERSION.deb"
+    wget --retry-connrefused --waitretry=1 -q "$DOWNLOAD_URL" -O $PACKAGE
     EXIT_CODE=$?
     if [ $EXIT_CODE -ne 0 ]; then
         log "[install_kibana] error downloading Kibana $KIBANA_VERSION"


### PR DESCRIPTION
This PR changes the template to use systemd for configuration Elasticsearch and Kibana, and removes monit from the template.

Monit was introduced into the template when it was in its infancy, almost 3 years ago, and was introduced to circumvent an Azure bug where Azure DNS was not available when starting the Elasticsearch process. Having a service monitor in place brought the template deployment failure rates down and monit initially solved this but doesn't do anything systemd can not do, or better. Further, [recent package versions of monit for Ubuntu appear to have introduced a bug for certain commands](https://bugs.launchpad.net/ubuntu/+source/monit/+bug/1786910). 

- Configure Elasticsearch with systemd
- Configure Kibana with systemd
- Update documentation to reflect this change

Closes #95 