### PR TITLE
Remove locations with 2 Fault domains from configuration

### DIFF
--- a/build/allowedValues.json
+++ b/build/allowedValues.json
@@ -239,56 +239,11 @@
     "centralus": { "platformFaultDomainCount": 3 },
     "northcentralus": { "platformFaultDomainCount": 3 },
     "southcentralus": { "platformFaultDomainCount": 3 },
-    "westcentralus": { "platformFaultDomainCount": 2 },
+
     "westus": { "platformFaultDomainCount": 3 },
-    "westus2": { "platformFaultDomainCount": 2 },
-    "canadaeast": { "platformFaultDomainCount": 2 },
-    "canadacentral": { "platformFaultDomainCount": 2 },
-    "brazilsouth": { "platformFaultDomainCount": 2 },
 
     "northeurope": { "platformFaultDomainCount": 3 },
-    "westeurope": { "platformFaultDomainCount": 3 },
-    "francecentral": { "platformFaultDomainCount": 2 },
-    "francesouth": { "platformFaultDomainCount": 2 },
-    "ukwest": { "platformFaultDomainCount": 2 },
-    "uksouth": { "platformFaultDomainCount": 2 },
-    "germanycentral": { "platformFaultDomainCount": 2 },
-    "germanynortheast": { "platformFaultDomainCount": 2 },
-
-    "germanynorth": { "platformFaultDomainCount": 2 },
-    "germanywestcentral": { "platformFaultDomainCount": 2 },
-    "switzerlandnorth": { "platformFaultDomainCount": 2 },
-    "switzerlandwest": { "platformFaultDomainCount": 2 },
-
-    "southeastasia": { "platformFaultDomainCount": 2 },
-    "eastasia": { "platformFaultDomainCount": 2 },
-    "australiaeast": { "platformFaultDomainCount": 2 },
-    "australiasoutheast": { "platformFaultDomainCount": 2 },
-    "australiacentral": { "platformFaultDomainCount": 2 },
-    "australiacentral2": { "platformFaultDomainCount": 2 },
-    "chinaeast": { "platformFaultDomainCount": 2 },
-    "chinanorth": { "platformFaultDomainCount": 2 },
-    "centralindia": { "platformFaultDomainCount": 2 },
-    "westindia": { "platformFaultDomainCount": 2 },
-    "southindia": { "platformFaultDomainCount": 2 },
-    "japaneast": { "platformFaultDomainCount": 2 },
-    "japanwest": { "platformFaultDomainCount": 2 },
-    "koreacentral": { "platformFaultDomainCount": 2 },
-    "koreasouth": { "platformFaultDomainCount": 2 },
-
-    "southafricawest": { "platformFaultDomainCount": 2 },
-    "southafricanorth": { "platformFaultDomainCount": 2 },
-    "uaecentral": { "platformFaultDomainCount": 2 },
-    "uaenorth": { "platformFaultDomainCount": 2 },
-
-    "usgovvirginia": { "platformFaultDomainCount": 2 },
-    "usgoviowa": { "platformFaultDomainCount": 2 },
-    "usgovarizona": { "platformFaultDomainCount": 2 },
-    "usgovtexas": { "platformFaultDomainCount": 2 },
-    "usdodeast": { "platformFaultDomainCount": 2 },
-    "usdodcentral": { "platformFaultDomainCount": 2 },
-    "usseceast": { "platformFaultDomainCount": 2 },
-    "ussecwest": { "platformFaultDomainCount": 2 }
+    "westeurope": { "platformFaultDomainCount": 3 }
   },
   "trackingGuids": {
     "marketplace": "pid-53DEEEE7-A572-4F07-99DC-151B67BB6F1F"

--- a/src/partials/node-resources.json
+++ b/src/partials/node-resources.json
@@ -70,140 +70,14 @@
       "southcentralus": {
         "platformFaultDomainCount": 3
       },
-      "westcentralus": {
-        "platformFaultDomainCount": 2
-      },
       "westus": {
         "platformFaultDomainCount": 3
-      },
-      "westus2": {
-        "platformFaultDomainCount": 2
-      },
-      "canadaeast": {
-        "platformFaultDomainCount": 2
-      },
-      "canadacentral": {
-        "platformFaultDomainCount": 2
-      },
-      "brazilsouth": {
-        "platformFaultDomainCount": 2
       },
       "northeurope": {
         "platformFaultDomainCount": 3
       },
       "westeurope": {
         "platformFaultDomainCount": 3
-      },
-      "francecentral": {
-        "platformFaultDomainCount": 2
-      },
-      "francesouth": {
-        "platformFaultDomainCount": 2
-      },
-      "ukwest": {
-        "platformFaultDomainCount": 2
-      },
-      "uksouth": {
-        "platformFaultDomainCount": 2
-      },
-      "germanycentral": {
-        "platformFaultDomainCount": 2
-      },
-      "germanynortheast": {
-        "platformFaultDomainCount": 2
-      },
-      "germanynorth": {
-        "platformFaultDomainCount": 2
-      },
-      "germanywestcentral": {
-        "platformFaultDomainCount": 2
-      },
-      "switzerlandnorth": {
-        "platformFaultDomainCount": 2
-      },
-      "switzerlandwest": {
-        "platformFaultDomainCount": 2
-      },
-      "southeastasia": {
-        "platformFaultDomainCount": 2
-      },
-      "eastasia": {
-        "platformFaultDomainCount": 2
-      },
-      "australiaeast": {
-        "platformFaultDomainCount": 2
-      },
-      "australiasoutheast": {
-        "platformFaultDomainCount": 2
-      },
-      "australiacentral": {
-        "platformFaultDomainCount": 2
-      },
-      "australiacentral2": {
-        "platformFaultDomainCount": 2
-      },
-      "chinaeast": {
-        "platformFaultDomainCount": 2
-      },
-      "chinanorth": {
-        "platformFaultDomainCount": 2
-      },
-      "centralindia": {
-        "platformFaultDomainCount": 2
-      },
-      "westindia": {
-        "platformFaultDomainCount": 2
-      },
-      "southindia": {
-        "platformFaultDomainCount": 2
-      },
-      "japaneast": {
-        "platformFaultDomainCount": 2
-      },
-      "japanwest": {
-        "platformFaultDomainCount": 2
-      },
-      "koreacentral": {
-        "platformFaultDomainCount": 2
-      },
-      "koreasouth": {
-        "platformFaultDomainCount": 2
-      },
-      "southafricawest": {
-        "platformFaultDomainCount": 2
-      },
-      "southafricanorth": {
-        "platformFaultDomainCount": 2
-      },
-      "uaecentral": {
-        "platformFaultDomainCount": 2
-      },
-      "uaenorth": {
-        "platformFaultDomainCount": 2
-      },
-      "usgovvirginia": {
-        "platformFaultDomainCount": 2
-      },
-      "usgoviowa": {
-        "platformFaultDomainCount": 2
-      },
-      "usgovarizona": {
-        "platformFaultDomainCount": 2
-      },
-      "usgovtexas": {
-        "platformFaultDomainCount": 2
-      },
-      "usdodeast": {
-        "platformFaultDomainCount": 2
-      },
-      "usdodcentral": {
-        "platformFaultDomainCount": 2
-      },
-      "usseceast": {
-        "platformFaultDomainCount": 2
-      },
-      "ussecwest": {
-        "platformFaultDomainCount": 2
       }
     },
     "normalizedLocation": "[replace(toLower(parameters('commonVmSettings').location), ' ', '')]",


### PR DESCRIPTION
This commit removes those locations that have only 2 Fault domains
from configuration. 2 Fault domains is the default.

Closes #234