### PR TITLE
Enable Log Analytics

### DIFF
--- a/src/machines/kibana-resources.json
+++ b/src/machines/kibana-resources.json
@@ -64,6 +64,20 @@
       "metadata": {
         "description": "Unique identifiers to allow the Azure Infrastructure to understand the origin of resources deployed to Azure. You do not need to supply a value for this."
       }
+    },
+    "logAnalyticsId": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Log Analytics ID"
+      }
+    },
+    "logAnalyticsKey": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Log Analytics Key"
+      }
     }
   },
   "variables": {
@@ -214,6 +228,27 @@
             "[concat('Microsoft.Compute/virtualMachines/', parameters('namespace'))]"
           ],
           "properties": "[parameters('osSettings').extensionSettings.kibana]"
+        },
+        {
+          "condition": "[not(empty(parameters('logAnalyticsId')))]",
+          "type": "Microsoft.Compute/virtualMachines/extensions",
+          "name": "[concat(variables('namespace'), '/OMSExtension')]",
+          "apiVersion": "2018-06-01",
+          "location": "[parameters('location')]",
+          "dependsOn": [
+            "[concat('Microsoft.Compute/virtualMachines/', parameters('namespace'))]"
+          ],
+          "properties": {
+            "publisher": "Microsoft.EnterpriseCloud.Monitoring",
+            "type": "OmsAgentForLinux",
+            "typeHandlerVersion": "1.7",
+            "settings": {
+              "workspaceId": "[parameters('logAnalyticsId')]"
+            },
+            "protectedSettings": {
+              "workspaceKey": "[parameters('logAnalyticsKey')]"
+            }
+          }
         }
       ]
     }

--- a/src/machines/kibana-resources.json
+++ b/src/machines/kibana-resources.json
@@ -225,7 +225,8 @@
           "apiVersion": "2017-12-01",
           "location": "[parameters('location')]",
           "dependsOn": [
-            "[concat('Microsoft.Compute/virtualMachines/', parameters('namespace'))]"
+            "[concat('Microsoft.Compute/virtualMachines/', parameters('namespace'))]",
+            "[resourceId('Microsoft.Compute/virtualMachines/extensions', parameters('namespace'), 'OMSExtension')]"
           ],
           "properties": "[parameters('osSettings').extensionSettings.kibana]"
         },

--- a/src/mainTemplate.json
+++ b/src/mainTemplate.json
@@ -1259,6 +1259,20 @@
       "metadata": {
         "description": "The Base-64 encoded certificate (.cer) used to secure the HTTP layer of Elasticsearch. Used by the Application Gateway to whitelist certificates used by the backend pool. Must be set if using esHttpCertBlob to secure the HTTP layer of Elasticsearch"
       }
+    },
+    "logAnalyticsId": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Log Anytics ID. Used by VMs for logging."
+      }
+    },
+    "logAnalyticsKey": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Log Anytics Key. Used by VMs for logging."
+      }
     }
   },
   "variables": {
@@ -1893,6 +1907,8 @@
       "location": "[variables('location')]",
       "subnet": "[variables('networkSettings').subnet]",
       "subnetId": "[concat(resourceId(variables('networkSettings').resourceGroup, 'Microsoft.Network/virtualNetworks', variables('networkSettings').name), '/subnets/', variables('networkSettings').subnet.name)]",
+      "logAnalyticsId": "[parameters('logAnalyticsId')]",
+      "logAnalyticsKey": "[parameters('logAnalyticsKey')]",
       "credentials": {
         "adminUsername": "[parameters('adminUsername')]",
         "password": "[parameters('adminPassword')]",

--- a/src/partials/node-resources.json
+++ b/src/partials/node-resources.json
@@ -341,6 +341,12 @@
           },
           "elasticTags": {
             "value": "[parameters('elasticTags')]"
+          },
+          "logAnalyticsId": {
+            "value": "[parameters('commonVmSettings').logAnalyticsId]"
+          },
+          "logAnalyticsKey": {
+            "value": "[parameters('commonVmSettings').logAnalyticsKey]"
           }
         }
       }

--- a/src/partials/vm.json
+++ b/src/partials/vm.json
@@ -142,7 +142,8 @@
           "apiVersion": "2017-12-01",
           "location": "[parameters('vm').shared.location]",
           "dependsOn": [
-            "[concat('Microsoft.Compute/virtualMachines/', variables('namespace'), parameters('index'))]"
+            "[concat('Microsoft.Compute/virtualMachines/', variables('namespace'), parameters('index'))]",
+            "[resourceId('Microsoft.Compute/virtualMachines/extensions', concat(variables('namespace'), parameters('index')), 'OMSExtension')]"
           ],
           "properties": "[parameters('vm').installScript]"
         },

--- a/src/partials/vm.json
+++ b/src/partials/vm.json
@@ -145,6 +145,27 @@
             "[concat('Microsoft.Compute/virtualMachines/', variables('namespace'), parameters('index'))]"
           ],
           "properties": "[parameters('vm').installScript]"
+        },
+        {
+          "condition": "[not(empty(parameters('vm').shared.logAnalyticsId))]",
+          "type": "Microsoft.Compute/virtualMachines/extensions",
+          "name": "[concat(variables('namespace'), parameters('index'), '/OMSExtension')]",
+          "apiVersion": "2018-06-01",
+          "location": "[parameters('vm').shared.location]",
+          "dependsOn": [
+            "[concat('Microsoft.Compute/virtualMachines/', variables('namespace'), parameters('index'))]"
+          ],
+          "properties": {
+            "publisher": "Microsoft.EnterpriseCloud.Monitoring",
+            "type": "OmsAgentForLinux",
+            "typeHandlerVersion": "1.7",
+            "settings": {
+              "workspaceId": "[parameters('vm').shared.logAnalyticsId]"
+            },
+            "protectedSettings": {
+              "workspaceKey": "[parameters('vm').shared.logAnalyticsKey]"
+            }
+          }
         }
       ]
     }


### PR DESCRIPTION
This allows a Log Analytics key to be added to the deployment to allow VMs to be associated with Log Analytics.

I've only done:
* Nodes
* Kibana

As these are all we're using.  If the approach is generally acceptable then I can possibly look at the other VMs (though I don't have an easy way to test those).