### PR TITLE
Remove double forward slashes in Template URIs

### DIFF
--- a/src/machines/client-nodes-resources.json
+++ b/src/machines/client-nodes-resources.json
@@ -58,7 +58,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(parameters('templateBaseUrl'), '/partials/vm.json')]",
+          "uri": "[concat(parameters('templateBaseUrl'), 'partials/vm.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {

--- a/src/machines/data-nodes-resources.json
+++ b/src/machines/data-nodes-resources.json
@@ -71,7 +71,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(parameters('templateBaseUrl'), '/partials/vm.json')]",
+          "uri": "[concat(parameters('templateBaseUrl'), 'partials/vm.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -128,7 +128,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(parameters('templateBaseUrl'), '/partials/vm.json')]",
+          "uri": "[concat(parameters('templateBaseUrl'), 'partials/vm.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {

--- a/src/machines/master-nodes-resources.json
+++ b/src/machines/master-nodes-resources.json
@@ -58,7 +58,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(parameters('templateBaseUrl'), '/partials/vm.json')]",
+          "uri": "[concat(parameters('templateBaseUrl'), 'partials/vm.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {


### PR DESCRIPTION
A recent change in the Azure Marketplace means that URIs that include
double forward slashes (//) no longer correctly resolve to linked resources.

This commit standardises the template URIs across the template.

Fixes #261