### PR TITLE
Add support for 8, 16 and 32 TiB managed disks

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Deploying through the Marketplace is great and easy way to get your feet wet for
 
 ![Example UI Flow](images/ui.gif)
 
-You can view the UI in developer mode by [clicking here](https://portal.azure.com/#blade/Microsoft_Azure_Compute/CreateMultiVmWizardBlade/internal_bladeCallId/anything/internal_bladeCallerParams/{"initialData":{},"providerConfig":{"createUiDefinition":"https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fazure-marketplace%2F6.7%2Fsrc%2FcreateUiDefinition.json"}}). If you feel something is cached improperly use [this client unoptimized link instead](https://portal.azure.com/?clientOptimizations=false#blade/Microsoft_Azure_Compute/CreateMultiVmWizardBlade/internal_bladeCallId/anything/internal_bladeCallerParams/{"initialData":{},"providerConfig":{"createUiDefinition":"https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fazure-marketplace%2F6.7%2Fsrc%2FcreateUiDefinition.json"}})
+You can view the UI in developer mode by [clicking here](https://portal.azure.com/#blade/Microsoft_Azure_Compute/CreateMultiVmWizardBlade/internal_bladeCallId/anything/internal_bladeCallerParams/{"initialData":{},"providerConfig":{"createUiDefinition":"https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fazure-marketplace%2Ffeature%2F267%2Fsrc%2FcreateUiDefinition.json"}}). If you feel something is cached improperly use [this client unoptimized link instead](https://portal.azure.com/?clientOptimizations=false#blade/Microsoft_Azure_Compute/CreateMultiVmWizardBlade/internal_bladeCallId/anything/internal_bladeCallerParams/{"initialData":{},"providerConfig":{"createUiDefinition":"https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fazure-marketplace%2Ffeature%2F267%2Fsrc%2FcreateUiDefinition.json"}})
 
 ## Reporting bugs
 
@@ -563,7 +563,7 @@ value defined in the template.
 
 ### Web based deploy
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fazure-marketplace%2F6.7%2Fsrc%2FmainTemplate.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fazure-marketplace%2Ffeature%2F267%2Fsrc%2FmainTemplate.json" target="_blank">
    <img alt="Deploy to Azure" src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 
@@ -597,7 +597,7 @@ supported by the last release. It's recommended to update to [Azure CLI 2.0](htt
 ```sh
 az group deployment create \
   --resource-group <name> \
-  --template-uri https://raw.githubusercontent.com/elastic/azure-marketplace/6.7/src/mainTemplate.json \
+  --template-uri https://raw.githubusercontent.com/elastic/azure-marketplace/feature/267/src/mainTemplate.json \
   --parameters @parameters/password.parameters.json
 ```
 
@@ -622,7 +622,7 @@ where `<name>` refers to the resource group you just created.
 
   ```powershell
   $clusterParameters = @{
-      "artifactsBaseUrl"="https://raw.githubusercontent.com/elastic/azure-marketplace/6.7/src"
+      "artifactsBaseUrl"="https://raw.githubusercontent.com/elastic/azure-marketplace/feature/267/src"
       "esVersion" = "6.7.0"
       "esClusterName" = "elasticsearch"
       "loadBalancerType" = "internal"
@@ -647,7 +647,7 @@ where `<name>` refers to the resource group you just created.
 5. Use our template directly from GitHub
 
   ```powershell
-  New-AzureRmResourceGroupDeployment -Name "<deployment name>" -ResourceGroupName "<name>" -TemplateUri "https://raw.githubusercontent.com/elastic/azure-marketplace/6.7/src/mainTemplate.json" -TemplateParameterObject $clusterParameters
+  New-AzureRmResourceGroupDeployment -Name "<deployment name>" -ResourceGroupName "<name>" -TemplateUri "https://raw.githubusercontent.com/elastic/azure-marketplace/feature/267/src/mainTemplate.json" -TemplateParameterObject $clusterParameters
   ```
 
 ## Targeting a specific template version

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Deploying through the Marketplace is great and easy way to get your feet wet for
 
 ![Example UI Flow](images/ui.gif)
 
-You can view the UI in developer mode by [clicking here](https://portal.azure.com/#blade/Microsoft_Azure_Compute/CreateMultiVmWizardBlade/internal_bladeCallId/anything/internal_bladeCallerParams/{"initialData":{},"providerConfig":{"createUiDefinition":"https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fazure-marketplace%2Ffeature%2F267%2Fsrc%2FcreateUiDefinition.json"}}). If you feel something is cached improperly use [this client unoptimized link instead](https://portal.azure.com/?clientOptimizations=false#blade/Microsoft_Azure_Compute/CreateMultiVmWizardBlade/internal_bladeCallId/anything/internal_bladeCallerParams/{"initialData":{},"providerConfig":{"createUiDefinition":"https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fazure-marketplace%2Ffeature%2F267%2Fsrc%2FcreateUiDefinition.json"}})
+You can view the UI in developer mode by [clicking here](https://portal.azure.com/#blade/Microsoft_Azure_Compute/CreateMultiVmWizardBlade/internal_bladeCallId/anything/internal_bladeCallerParams/{"initialData":{},"providerConfig":{"createUiDefinition":"https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fazure-marketplace%2F6.7%2Fsrc%2FcreateUiDefinition.json"}}). If you feel something is cached improperly use [this client unoptimized link instead](https://portal.azure.com/?clientOptimizations=false#blade/Microsoft_Azure_Compute/CreateMultiVmWizardBlade/internal_bladeCallId/anything/internal_bladeCallerParams/{"initialData":{},"providerConfig":{"createUiDefinition":"https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fazure-marketplace%2F6.7%2Fsrc%2FcreateUiDefinition.json"}})
 
 ## Reporting bugs
 
@@ -563,7 +563,7 @@ value defined in the template.
 
 ### Web based deploy
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fazure-marketplace%2Ffeature%2F267%2Fsrc%2FmainTemplate.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fazure-marketplace%2F6.7%2Fsrc%2FmainTemplate.json" target="_blank">
    <img alt="Deploy to Azure" src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 
@@ -597,7 +597,7 @@ supported by the last release. It's recommended to update to [Azure CLI 2.0](htt
 ```sh
 az group deployment create \
   --resource-group <name> \
-  --template-uri https://raw.githubusercontent.com/elastic/azure-marketplace/feature/267/src/mainTemplate.json \
+  --template-uri https://raw.githubusercontent.com/elastic/azure-marketplace/6.7/src/mainTemplate.json \
   --parameters @parameters/password.parameters.json
 ```
 
@@ -622,7 +622,7 @@ where `<name>` refers to the resource group you just created.
 
   ```powershell
   $clusterParameters = @{
-      "artifactsBaseUrl"="https://raw.githubusercontent.com/elastic/azure-marketplace/feature/267/src"
+      "artifactsBaseUrl"="https://raw.githubusercontent.com/elastic/azure-marketplace/6.7/src"
       "esVersion" = "6.7.0"
       "esClusterName" = "elasticsearch"
       "loadBalancerType" = "internal"
@@ -647,7 +647,7 @@ where `<name>` refers to the resource group you just created.
 5. Use our template directly from GitHub
 
   ```powershell
-  New-AzureRmResourceGroupDeployment -Name "<deployment name>" -ResourceGroupName "<name>" -TemplateUri "https://raw.githubusercontent.com/elastic/azure-marketplace/feature/267/src/mainTemplate.json" -TemplateParameterObject $clusterParameters
+  New-AzureRmResourceGroupDeployment -Name "<deployment name>" -ResourceGroupName "<name>" -TemplateUri "https://raw.githubusercontent.com/elastic/azure-marketplace/6.7/src/mainTemplate.json" -TemplateParameterObject $clusterParameters
   ```
 
 ## Targeting a specific template version

--- a/README.md
+++ b/README.md
@@ -291,11 +291,11 @@ value defined in the template.
     </td><td><a href="https://docs.microsoft.com/en-us/azure/virtual-machines/linux/sizes">Maximum number supported disks for data node VM size</a></td></tr>
 
   <tr><td>vmDataDiskSize</td><td>string</td>
-    <td>The disk size of each attached disk. Choose <code>XXLarge</code> (4095Gb), <code>XLarge</code> (2048Gb), <code>Large</code> (1024Gb), <code>Medium</code> (512Gb) or <code>Small</code> (128Gb).
-    For Premium Storage, disk sizes equate to <a href="https://docs.microsoft.com/en-us/azure/storage/storage-premium-storage#premium-storage-disks-limits">P50, P40, P30, P20 and P10</a>
+    <td>The disk size of each attached disk. Choose <code>32TiB</code>, <code>16TiB</code>, <code>8TiB</code>, <code>4TiB</code>, <code>2TiB</code>, <code>1TiB</code>, <code>512GiB</code>, <code>256GiB</code>, <code>128GiB</code>, <code>64GiB</code> or <code>32GiB</code>.
+    For Premium Storage, disk sizes equate to <a href="https://docs.microsoft.com/en-us/azure/storage/storage-premium-storage#premium-storage-disks-limits">P80, P70, P60, P50, P40, P30, P20, P15, P10 and P6</a>
     storage disk types, respectively.
     </td>
-  </td><td><code>Large</code></td></tr>
+  </td><td><code>1TiB</code></td></tr>
 
   <tr><td>storageAccountType</td><td>string</td>
     <td>The storage account type of the attached disks. Choose either <code>Default</code> or <code>Standard</code>. 

--- a/build/allowedValues.json
+++ b/build/allowedValues.json
@@ -12,7 +12,8 @@
   ],
   "numberOfDataNodes" : 50,
   "numberOfClientNodes" : 20,
-  "diskSizes" : ["Small", "Medium", "Large", "XLarge", "XXLarge"],
+  "diskSizes" : ["32GiB", "64GiB", "128GiB", "256GiB", "512GiB", "1TiB", "2TiB", "4TiB", "8TiB", "16TiB", "32TiB"],
+  "defaultDiskSize": "1TiB",
   "vmAcceleratedNetworking": [
     "Standard_D2_v2",
     "Standard_D3_v2",

--- a/build/arm-tests/1000d-0m-0c-ext-kp0.json
+++ b/build/arm-tests/1000d-0m-0c-ext-kp0.json
@@ -11,7 +11,7 @@
 		"vmSizeDataNodes":{"value":"Standard_D1"},
 		"vmDataNodeCount":{"value":1000},
 		"vmDataDiskCount":{"value":40},
-		"vmDataDiskSize":{"value":"Small"},
+		"vmDataDiskSize":{"value":"32GiB"},
 		"storageAccountType":{"value":"Default"},
 		"dataNodesAreMasterEligible":{"value":"Yes"},
 		"vmSizeMasterNodes":{"value":"Standard_DS2"},

--- a/build/arm-tests/120d-3m-30c-ext-kp.json
+++ b/build/arm-tests/120d-3m-30c-ext-kp.json
@@ -12,7 +12,7 @@
 		"vmDataNodeCount":{"value":120},
 		"dataNodesAreMasterEligible":{"value":"No"},
 		"vmDataDiskCount":{"value":40},
-		"vmDataDiskSize":{"value":"Small"},
+		"vmDataDiskSize":{"value":"32GiB"},
 		"storageAccountType":{"value":"Default"},
 		"vmSizeMasterNodes":{"value":"Standard_DS2"},
 		"vmClientNodeCount":{"value":30},

--- a/build/arm-tests/1d-0m-0c-ext-klp.json
+++ b/build/arm-tests/1d-0m-0c-ext-klp.json
@@ -15,7 +15,7 @@
     "vmSizeDataNodes":{"value":"Standard_DS1_v2"},
     "vmDataNodeCount":{"value":1},
     "vmDataDiskCount":{"value":1},
-    "vmDataDiskSize":{"value":"Small"},
+    "vmDataDiskSize":{"value":"32GiB"},
     "storageAccountType":{"value":"Default"},
     "dataNodesAreMasterEligible":{"value":"Yes"},
     "authenticationType":{"value":"password"}

--- a/build/arm-tests/1d-0m-0c-ext-p.json
+++ b/build/arm-tests/1d-0m-0c-ext-p.json
@@ -12,7 +12,7 @@
 		"vmSizeDataNodes":{"value":"Standard_DS1_v2"},
 		"vmDataNodeCount":{"value":1},
 		"vmDataDiskCount":{"value":0},
-		"vmDataDiskSize":{"value":"Small"},
+		"vmDataDiskSize":{"value":"32GiB"},
 		"storageAccountType":{"value":"Default"},
 		"dataNodesAreMasterEligible":{"value":"Yes"},
 		"vmSizeMasterNodes":{"value":"Standard_DS2"},

--- a/build/arm-tests/1d-0m-0c-ext-tls-klp.json
+++ b/build/arm-tests/1d-0m-0c-ext-tls-klp.json
@@ -25,7 +25,7 @@
     "vmSizeDataNodes":{"value":"Standard_DS1_v2"},
     "vmDataNodeCount":{"value":1},
     "vmDataDiskCount":{"value":1},
-    "vmDataDiskSize":{"value":"Small"},
+    "vmDataDiskSize":{"value":"32GiB"},
     "storageAccountType":{"value":"Default"},
     "dataNodesAreMasterEligible":{"value":"Yes"},
     "authenticationType":{"value":"password"}

--- a/build/arm-tests/1d-0m-0c-int-kp-yml.json
+++ b/build/arm-tests/1d-0m-0c-int-kp-yml.json
@@ -15,7 +15,7 @@
 		"vmSizeDataNodes":{"value":"Standard_DS1_v2"},
 		"vmDataNodeCount":{"value":1},
 		"vmDataDiskCount":{"value":0},
-		"vmDataDiskSize":{"value":"Small"},
+		"vmDataDiskSize":{"value":"32GiB"},
 		"storageAccountType":{"value":"Default"},
 		"dataNodesAreMasterEligible":{"value":"Yes"},
 		"vmSizeMasterNodes":{"value":"Standard_DS2"},

--- a/build/arm-tests/1d-xxl-0m-0c-ext-p.json
+++ b/build/arm-tests/1d-xxl-0m-0c-ext-p.json
@@ -1,5 +1,5 @@
 {
-  "description": "1 data node cluster using XXLarge (4095GB) disks",
+  "description": "1 data node cluster using 32TiB disks",
 	"isValid" : true,
 	"deploy" : true,
 	"why" : "",
@@ -12,7 +12,7 @@
 		"vmSizeDataNodes":{"value":"Standard_D2s_v3"},
 		"vmDataNodeCount":{"value":1},
 		"vmDataDiskCount":{"value":4},
-		"vmDataDiskSize":{"value":"XXLarge"},
+		"vmDataDiskSize":{"value":"32TiB"},
 		"storageAccountType":{"value":"Default"},
 		"dataNodesAreMasterEligible":{"value":"Yes"},
 		"vmSizeMasterNodes":{"value":"Standard_DS2"},

--- a/build/arm-tests/3000d-0m-0c-ext-kp.json
+++ b/build/arm-tests/3000d-0m-0c-ext-kp.json
@@ -11,7 +11,7 @@
 		"vmSizeDataNodes":{"value":"Standard_D1"},
 		"vmDataNodeCount":{"value":3000},
 		"vmDataDiskCount":{"value":40},
-		"vmDataDiskSize":{"value":"Small"},
+		"vmDataDiskSize":{"value":"32GiB"},
 		"storageAccountType":{"value":"Default"},
 		"dataNodesAreMasterEligible":{"value":"Yes"},
 		"vmSizeMasterNodes":{"value":"Standard_DS2"},

--- a/build/arm-tests/3d-0m-0c-ags-ks.json
+++ b/build/arm-tests/3d-0m-0c-ags-ks.json
@@ -11,7 +11,7 @@
 		"vmSizeDataNodes":{"value":"Standard_D1"},
 		"vmDataNodeCount":{"value":3},
 		"vmDataDiskCount":{"value":40},
-		"vmDataDiskSize":{"value":"Small"},
+		"vmDataDiskSize":{"value":"32GiB"},
 		"storageAccountType":{"value":"Default"},
 		"dataNodesAreMasterEligible":{"value":"Yes"},
 		"vmSizeMasterNodes":{"value":"Standard_DS2"},

--- a/build/arm-tests/3d-0m-0c-ags-tls.json
+++ b/build/arm-tests/3d-0m-0c-ags-tls.json
@@ -12,7 +12,7 @@
 		"vmSizeDataNodes":{"value":"Standard_D1"},
 		"vmDataNodeCount":{"value":3},
 		"vmDataDiskCount":{"value":0},
-		"vmDataDiskSize":{"value":"Small"},
+		"vmDataDiskSize":{"value":"32GiB"},
 		"storageAccountType":{"value":"Default"},
 		"dataNodesAreMasterEligible":{"value":"Yes"},
 		"vmSizeMasterNodes":{"value":"Standard_DS2"},

--- a/build/arm-tests/3d-0m-0c-agw-ks.json
+++ b/build/arm-tests/3d-0m-0c-agw-ks.json
@@ -11,7 +11,7 @@
 		"vmSizeDataNodes":{"value":"Standard_D1"},
 		"vmDataNodeCount":{"value":3},
 		"vmDataDiskCount":{"value":40},
-		"vmDataDiskSize":{"value":"Small"},
+		"vmDataDiskSize":{"value":"32GiB"},
 		"storageAccountType":{"value":"Default"},
 		"dataNodesAreMasterEligible":{"value":"Yes"},
 		"vmSizeMasterNodes":{"value":"Standard_DS2"},

--- a/build/arm-tests/3d-0m-0c-ext-kp-no-disks.json
+++ b/build/arm-tests/3d-0m-0c-ext-kp-no-disks.json
@@ -11,7 +11,7 @@
 		"vmSizeDataNodes":{"value":"Standard_D1"},
 		"vmDataNodeCount":{"value":3},
 		"vmDataDiskCount":{"value":0},
-		"vmDataDiskSize":{"value":"Small"},
+		"vmDataDiskSize":{"value":"32GiB"},
 		"storageAccountType":{"value":"Default"},
 		"dataNodesAreMasterEligible":{"value":"Yes"},
 		"vmSizeMasterNodes":{"value":"Standard_DS2"},

--- a/build/arm-tests/3d-0m-0c-ext-kp.json
+++ b/build/arm-tests/3d-0m-0c-ext-kp.json
@@ -11,7 +11,7 @@
 		"vmSizeDataNodes":{"value":"Standard_D1"},
 		"vmDataNodeCount":{"value":3},
 		"vmDataDiskCount":{"value":40},
-		"vmDataDiskSize":{"value":"Small"},
+		"vmDataDiskSize":{"value":"32GiB"},
 		"storageAccountType":{"value":"Default"},
 		"dataNodesAreMasterEligible":{"value":"Yes"},
 		"vmSizeMasterNodes":{"value":"Standard_DS2"},

--- a/build/arm-tests/3d-0m-0c-ext-ks.json
+++ b/build/arm-tests/3d-0m-0c-ext-ks.json
@@ -11,7 +11,7 @@
 		"vmSizeDataNodes":{"value":"Standard_D1"},
 		"vmDataNodeCount":{"value":3},
 		"vmDataDiskCount":{"value":40},
-		"vmDataDiskSize":{"value":"Small"},
+		"vmDataDiskSize":{"value":"32GiB"},
 		"storageAccountType":{"value":"Default"},
 		"dataNodesAreMasterEligible":{"value":"Yes"},
 		"vmSizeMasterNodes":{"value":"Standard_DS2"},

--- a/build/arm-tests/3d-0m-0c-ext-tls-kp.json
+++ b/build/arm-tests/3d-0m-0c-ext-tls-kp.json
@@ -15,7 +15,7 @@
 		"vmSizeDataNodes":{"value":"Standard_D1"},
 		"vmDataNodeCount":{"value":3},
 		"vmDataDiskCount":{"value":40},
-		"vmDataDiskSize":{"value":"Small"},
+		"vmDataDiskSize":{"value":"32GiB"},
 		"storageAccountType":{"value":"Default"},
 		"dataNodesAreMasterEligible":{"value":"Yes"},
 		"vmSizeMasterNodes":{"value":"Standard_DS2"},

--- a/build/arm-tests/3d-0m-0c-ext-tls-pass-kp.json
+++ b/build/arm-tests/3d-0m-0c-ext-tls-pass-kp.json
@@ -19,7 +19,7 @@
 		"vmSizeDataNodes":{"value":"Standard_D1"},
 		"vmDataNodeCount":{"value":3},
 		"vmDataDiskCount":{"value":40},
-		"vmDataDiskSize":{"value":"Small"},
+		"vmDataDiskSize":{"value":"32GiB"},
 		"storageAccountType":{"value":"Default"},
 		"dataNodesAreMasterEligible":{"value":"Yes"},
 		"vmSizeMasterNodes":{"value":"Standard_DS2"},

--- a/build/arm-tests/3d-0m-3c-ext-kp-location.json
+++ b/build/arm-tests/3d-0m-3c-ext-kp-location.json
@@ -11,7 +11,7 @@
 		"vmSizeDataNodes":{"value":"Standard_D1"},
 		"vmDataNodeCount":{"value":3},
 		"vmDataDiskCount":{"value":40},
-		"vmDataDiskSize":{"value":"Small"},
+		"vmDataDiskSize":{"value":"32GiB"},
 		"storageAccountType":{"value":"Default"},
 		"dataNodesAreMasterEligible":{"value":"Yes"},
 		"vmSizeMasterNodes":{"value":"Standard_DS2"},

--- a/build/arm-tests/3d-3m-3c-int-jp.json
+++ b/build/arm-tests/3d-3m-3c-int-jp.json
@@ -11,7 +11,7 @@
 		"vmSizeDataNodes":{"value":"Standard_D1"},
 		"vmDataNodeCount":{"value":3},
 		"vmDataDiskCount":{"value":40},
-		"vmDataDiskSize":{"value":"Small"},
+		"vmDataDiskSize":{"value":"32GiB"},
 		"storageAccountType":{"value":"Default"},
 		"dataNodesAreMasterEligible":{"value":"Yes"},
 		"vmSizeMasterNodes":{"value":"Standard_DS2"},

--- a/build/arm-tests/6d-0m-0c-ext-p-big-vm-size.json
+++ b/build/arm-tests/6d-0m-0c-ext-p-big-vm-size.json
@@ -11,7 +11,7 @@
 		"vmSizeDataNodes":{"value":"Standard_DS3"},
 		"vmDataNodeCount":{"value":6},
 		"vmDataDiskCount":{"value":40},
-		"vmDataDiskSize":{"value":"Small"},
+		"vmDataDiskSize":{"value":"32GiB"},
 		"storageAccountType":{"value":"Default"},
 		"dataNodesAreMasterEligible":{"value":"Yes"},
 		"vmSizeMasterNodes":{"value":"Standard_DS3"},

--- a/build/tasks/arm-validator.js
+++ b/build/tasks/arm-validator.js
@@ -74,6 +74,7 @@ var bootstrapTest = (t, defaultVersion) =>
   testParameters.securityReadPassword.value = config.deployments.securityPassword;
   testParameters.securityKibanaPassword.value = config.deployments.securityPassword;
   testParameters.securityLogstashPassword.value = config.deployments.securityPassword;
+  testParameters.securityBeatsPassword.value = config.deployments.securityPassword;
   testParameters.esVersion.value = defaultVersion;
 
   // Some parameters are longer than the max allowed characters for cmd on Windows.

--- a/build/tasks/patch-values.js
+++ b/build/tasks/patch-values.js
@@ -55,7 +55,7 @@ gulp.task("patch", function(cb) {
         main.parameters.vmSizeDataNodes.allowedValues = vmSizes;
         main.parameters.vmDataDiskCount.defaultValue = _(allowedValues.vmSizes).map((vm) => vm[1]).max();
         main.parameters.vmDataDiskSize.allowedValues = diskSizes;
-        main.parameters.vmDataDiskSize.defaultValue = "Large";
+        main.parameters.vmDataDiskSize.defaultValue = allowedValues.defaultDiskSize;
         main.parameters.vmSizeMasterNodes.allowedValues = vmSizes;
         main.parameters.vmSizeClientNodes.allowedValues = vmSizes;
         main.parameters.vmSizeKibana.allowedValues = kibanaVmSizes;
@@ -72,13 +72,12 @@ gulp.task("patch", function(cb) {
               return el.name == "esVersion";
             });
             versionControl.constraints.allowedValues = _.map(versions, function(v) {
-              return { label: "v" + v, value : v};
+              return { label: "v" + v, value : v };
             });
             versionControl.defaultValue = "v" + _.last(versions);
 
             //patch allowedVMSizes on the nodesStep
             var nodesStep = _.find(ui.parameters.steps, function (step) { return step.name == "nodesStep"; });
-
             var dataNodesSection = _.find(nodesStep.elements, function (el) { return el.name == "dataNodes"; });
             var masterNodesSection = _.find(nodesStep.elements, function (el) { return el.name == "masterNodes"; });
             var clientNodesSection = _.find(nodesStep.elements, function (el) { return el.name == "clientNodes"; });
@@ -120,6 +119,14 @@ gulp.task("patch", function(cb) {
             dataNodeCountControl.constraints.allowedValues = dataNodeValues;
             var clientNodeCountControl = _.find(clientNodesSection.elements, function (el) { return el.name == "vmClientNodeCount"; });
             clientNodeCountControl.constraints.allowedValues = clientNodeValues;
+
+            var dataNodesDisksSection = _.find(nodesStep.elements, function (el) { return el.name == "dataNodesDisks"; });
+            var dataDisksControl = _.find(dataNodesDisksSection.elements, function (el) { return el.name == "vmDataDiskSize"; });
+
+            dataDisksControl.constraints.allowedValues = _.map(diskSizes, function(d) {
+              return { label: d, value : d };
+            });
+            dataDisksControl.defaultValue = allowedValues.defaultDiskSize;;
 
             jsonfile.writeFile(uiTemplate, ui, function (err) {
               cb();

--- a/docs/azure-arm-template.asciidoc
+++ b/docs/azure-arm-template.asciidoc
@@ -525,14 +525,20 @@ managed disks, and Standard HDD disks for those that do not. The default is `Def
 The size of each attached managed disk. Choose between
 +
 [horizontal]
-`XXLarge`::: 4095 GB
-`XLarge`::: 2048 GB
-`Large`::: 1024 GB
-`Medium`::: 512 GB
-`Small`::: 128 GB
+`32TiB`::: 32 Tebibytes
+`16TiB`::: 16 Tebibytes
+`8TiB`::: 8 Tebibytes
+`4TiB`::: 4 Tebibytes
+`2TiB`::: 2 Tebibytes
+`1TiB`::: 1 Tebibyte
+`512GiB`::: 512 Gibibytes
+`256GiB`::: 256 Gibibytes
+`128GiB`::: 126 Gibibytes
+`64GiB`::: 64 Gibibytes
+`32GiB`::: 32 Gibibytes
 
 +
-Default is `Large`.
+Default is `1TiB`.
 
 `vmDataDiskCount`::
 The number of managed disks to attach to _each_ data node. The total number of

--- a/docs/faqs.asciidoc
+++ b/docs/faqs.asciidoc
@@ -11,7 +11,7 @@ and network interfaces
 * 1 availability set for master nodes
 * 3 data node Standard DS1 v2 SKU VMs running Ubuntu 16.04 with OS disks, network
 interfaces and one
-1024Gb managed disk per data node
+1TiB managed disk per data node
 * 1 availability set for data nodes
 * 1 Kibana Standard D1 SKU VM running Ubuntu 16.04 with OS disk, network interface,
 network security group and public IP address

--- a/parameters/password.parameters.json
+++ b/parameters/password.parameters.json
@@ -1,5 +1,5 @@
 {
-  "artifactsBaseUrl":{"value":"https://raw.githubusercontent.com/elastic/azure-marketplace/feature/267/src"},
+  "artifactsBaseUrl":{"value":"https://raw.githubusercontent.com/elastic/azure-marketplace/6.7/src"},
   "esVersion":{"value":"6.7.0"},
   "esClusterName":{"value":"my-azure-cluster"},
   "loadBalancerType":{"value":"internal"},

--- a/parameters/password.parameters.json
+++ b/parameters/password.parameters.json
@@ -39,7 +39,7 @@
   "vmSizeDataNodes":{"value":"Standard_D1"},
   "vmDataNodeAcceleratedNetworking":{"value":"Default"},
   "vmDataDiskCount":{"value":40},
-  "vmDataDiskSize":{"value":"Small"},
+  "vmDataDiskSize":{"value":"32GiB"},
   "vmDataNodeCount":{"value":3},
   "storageAccountType":{"value":"Default"},
   "dataNodesAreMasterEligible":{"value":"Yes"},

--- a/parameters/password.parameters.json
+++ b/parameters/password.parameters.json
@@ -1,5 +1,5 @@
 {
-  "artifactsBaseUrl":{"value":"https://raw.githubusercontent.com/elastic/azure-marketplace/6.7/src"},
+  "artifactsBaseUrl":{"value":"https://raw.githubusercontent.com/elastic/azure-marketplace/feature/267/src"},
   "esVersion":{"value":"6.7.0"},
   "esClusterName":{"value":"my-azure-cluster"},
   "loadBalancerType":{"value":"internal"},

--- a/parameters/ssh.parameters.json
+++ b/parameters/ssh.parameters.json
@@ -1,5 +1,5 @@
 {
-  "artifactsBaseUrl":{"value":"https://raw.githubusercontent.com/elastic/azure-marketplace/feature/267/src"},
+  "artifactsBaseUrl":{"value":"https://raw.githubusercontent.com/elastic/azure-marketplace/6.7/src"},
   "esVersion":{"value":"6.7.0"},
   "esClusterName":{"value":"my-azure-cluster"},
   "loadBalancerType":{"value":"internal"},

--- a/parameters/ssh.parameters.json
+++ b/parameters/ssh.parameters.json
@@ -39,7 +39,7 @@
   "vmSizeDataNodes":{"value":"Standard_D1"},
   "vmDataNodeAcceleratedNetworking":{"value":"Default"},
   "vmDataDiskCount":{"value":40},
-  "vmDataDiskSize":{"value":"Small"},
+  "vmDataDiskSize":{"value":"32GiB"},
   "vmDataNodeCount":{"value":3},
   "storageAccountType":{"value":"Default"},
   "dataNodesAreMasterEligible":{"value":"Yes"},

--- a/parameters/ssh.parameters.json
+++ b/parameters/ssh.parameters.json
@@ -1,5 +1,5 @@
 {
-  "artifactsBaseUrl":{"value":"https://raw.githubusercontent.com/elastic/azure-marketplace/6.7/src"},
+  "artifactsBaseUrl":{"value":"https://raw.githubusercontent.com/elastic/azure-marketplace/feature/267/src"},
   "esVersion":{"value":"6.7.0"},
   "esClusterName":{"value":"my-azure-cluster"},
   "loadBalancerType":{"value":"internal"},

--- a/src/createUiDefinition.json
+++ b/src/createUiDefinition.json
@@ -458,29 +458,53 @@
                 "type": "Microsoft.Common.DropDown",
                 "label": "Size of each managed disk",
                 "visible": "[greater(steps('nodesStep').dataNodesDisks.vmDataDiskCount, 0)]",
-                "defaultValue": "Large (1024Gb)",
+                "defaultValue": "1TiB",
                 "toolTip": "The size of each data disk to attach to each data node",
                 "constraints": {
                   "allowedValues": [
                     {
-                      "label": "Small (128Gb)",
-                      "value": "Small"
+                      "label": "32GiB",
+                      "value": "32GiB"
                     },
                     {
-                      "label": "Medium (512Gb)",
-                      "value": "Medium"
+                      "label": "64GiB",
+                      "value": "64GiB"
                     },
                     {
-                      "label": "Large (1024Gb)",
-                      "value": "Large"
+                      "label": "128GiB",
+                      "value": "128GiB"
                     },
                     {
-                      "label": "Extra Large (2048Gb)",
-                      "value": "XLarge"
+                      "label": "256GiB",
+                      "value": "256GiB"
                     },
                     {
-                      "label": "Extra Extra Large (4095Gb)",
-                      "value": "XXLarge"
+                      "label": "512GiB",
+                      "value": "512GiB"
+                    },
+                    {
+                      "label": "1TiB",
+                      "value": "1TiB"
+                    },
+                    {
+                      "label": "2TiB",
+                      "value": "2TiB"
+                    },
+                    {
+                      "label": "4TiB",
+                      "value": "4TiB"
+                    },
+                    {
+                      "label": "8TiB",
+                      "value": "8TiB"
+                    },
+                    {
+                      "label": "16TiB",
+                      "value": "16TiB"
+                    },
+                    {
+                      "label": "32TiB",
+                      "value": "32TiB"
                     }
                   ]
                 }

--- a/src/mainTemplate.json
+++ b/src/mainTemplate.json
@@ -4,7 +4,7 @@
   "parameters": {
     "artifactsBaseUrl": {
       "type": "string",
-      "defaultValue": "https://raw.githubusercontent.com/elastic/azure-marketplace/6.7/src",
+      "defaultValue": "https://raw.githubusercontent.com/elastic/azure-marketplace/feature/267/src",
       "metadata": {
         "artifactsBaseUrl": "Base URL of the Elastic template gallery package"
       }

--- a/src/mainTemplate.json
+++ b/src/mainTemplate.json
@@ -725,16 +725,22 @@
     },
     "vmDataDiskSize": {
       "type": "string",
-      "defaultValue": "Large",
+      "defaultValue": "1TiB",
       "allowedValues": [
-        "Small",
-        "Medium",
-        "Large",
-        "XLarge",
-        "XXLarge"
+        "32GiB",
+        "64GiB",
+        "128GiB",
+        "256GiB",
+        "512GiB",
+        "1TiB",
+        "2TiB",
+        "4TiB",
+        "8TiB",
+        "16TiB",
+        "32TiB"
       ],
       "metadata": {
-        "description": "The disk size of each attached disk, Small (128Gb), Medium (512Gb), Large (1024Gb), XLarge (2048Gb) and XXLarge (4095Gb). For Premium Storage, this equates to P10, P20, P30, P40 and P50, respectively."
+        "description": "The disk size of each attached managed disk, 32GiB, 64GiB, 128GiB, 256 GiB, 512GiB, 1TiB, 2TiB, 4TiB, 8TiB, 16TiB and 32TiB. Default is 1TiB. For Premium Storage, this equates to P6, P10, P15, P20, P30, P40, P50, P60, P70 and P80, respectively."
       }
     },
     "vmDataNodeCount": {
@@ -753,7 +759,7 @@
         "Standard"
       ],
       "metadata": {
-        "description": "The storage account type of the attached disks (Default or Standard). The Default storage account type will be Premium Storage for VMs that support Premium Storage and Standard Storage for those that do not."
+        "description": "The storage account type of the attached managed disks and OS disks (Default or Standard). The Default storage account type will be Premium Storage for VMs that support Premium Storage and Standard HDD Storage for those that do not."
       }
     },
     "dataNodesAreMasterEligible": {
@@ -917,7 +923,7 @@
       "defaultValue": 0,
       "minValue": 0,
       "metadata": {
-        "description": "Number of Elasticsearch coordinating nodes to provision. A value of 0 puts the data nodes on the load balancer"
+        "description": "Number of Elasticsearch coordinating nodes to provision. A value of 0 puts the data nodes in the load balancer backend pool"
       }
     },
     "vmSizeClientNodes": {
@@ -1825,11 +1831,17 @@
       }
     },
     "dataDiskSizes": {
-      "XXLarge": 4095,
-      "XLarge": 2048,
-      "Large": 1024,
-      "Medium": 512,
-      "Small": 128
+      "32GiB": 32,
+      "64GiB": 64,
+      "128GiB": 128,
+      "256GiB": 256,
+      "512GiB": 512,
+      "1TiB": 1024,
+      "2TiB": 2048,
+      "4TiB": 4096,
+      "8TiB": 8192,
+      "16TiB": 16384,
+      "32TiB": 32767
     },
     "backendPoolConfigurations": {
       "internal": [

--- a/src/mainTemplate.json
+++ b/src/mainTemplate.json
@@ -4,7 +4,7 @@
   "parameters": {
     "artifactsBaseUrl": {
       "type": "string",
-      "defaultValue": "https://raw.githubusercontent.com/elastic/azure-marketplace/feature/267/src",
+      "defaultValue": "https://raw.githubusercontent.com/elastic/azure-marketplace/6.7/src",
       "metadata": {
         "artifactsBaseUrl": "Base URL of the Elastic template gallery package"
       }


### PR DESCRIPTION
This PR adds support for larger Azure Managed disks.
As part of this support, change the disk sizes over from T-shirt like sizes
to more meaningful names e.g. Small -> 128GiB.

Closes #267 