### PR TITLE
Allow multiple instances of Logstash to be deployed

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Deploying through the Marketplace is great and easy way to get your feet wet for
 
 ![Example UI Flow](images/ui.gif)
 
-You can view the UI in developer mode by [clicking here](https://portal.azure.com/#blade/Microsoft_Azure_Compute/CreateMultiVmWizardBlade/internal_bladeCallId/anything/internal_bladeCallerParams/{"initialData":{},"providerConfig":{"createUiDefinition":"https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fazure-marketplace%2Ffeature%2F247%2Fsrc%2FcreateUiDefinition.json"}}). If you feel something is cached improperly use [this client unoptimized link instead](https://portal.azure.com/?clientOptimizations=false#blade/Microsoft_Azure_Compute/CreateMultiVmWizardBlade/internal_bladeCallId/anything/internal_bladeCallerParams/{"initialData":{},"providerConfig":{"createUiDefinition":"https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fazure-marketplace%2Ffeature%2F247%2Fsrc%2FcreateUiDefinition.json"}})
+You can view the UI in developer mode by [clicking here](https://portal.azure.com/#blade/Microsoft_Azure_Compute/CreateMultiVmWizardBlade/internal_bladeCallId/anything/internal_bladeCallerParams/{"initialData":{},"providerConfig":{"createUiDefinition":"https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fazure-marketplace%2F7.2%2Fsrc%2FcreateUiDefinition.json"}}). If you feel something is cached improperly use [this client unoptimized link instead](https://portal.azure.com/?clientOptimizations=false#blade/Microsoft_Azure_Compute/CreateMultiVmWizardBlade/internal_bladeCallId/anything/internal_bladeCallerParams/{"initialData":{},"providerConfig":{"createUiDefinition":"https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fazure-marketplace%2F7.2%2Fsrc%2FcreateUiDefinition.json"}})
 
 ## Reporting bugs
 
@@ -556,7 +556,7 @@ value defined in the template.
 
 ### Web based deploy
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fazure-marketplace%2Ffeature%2F247%2Fsrc%2FmainTemplate.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fazure-marketplace%2F7.2%2Fsrc%2FmainTemplate.json" target="_blank">
    <img alt="Deploy to Azure" src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 
@@ -590,7 +590,7 @@ supported by the last release. It's recommended to update to [Azure CLI 2.0](htt
 ```sh
 az group deployment create \
   --resource-group <name> \
-  --template-uri https://raw.githubusercontent.com/elastic/azure-marketplace/feature/247/src/mainTemplate.json \
+  --template-uri https://raw.githubusercontent.com/elastic/azure-marketplace/7.2/src/mainTemplate.json \
   --parameters @parameters/password.parameters.json
 ```
 
@@ -615,7 +615,7 @@ where `<name>` refers to the resource group you just created.
 
   ```powershell
   $clusterParameters = @{
-      "artifactsBaseUrl"="https://raw.githubusercontent.com/elastic/azure-marketplace/feature/247/src"
+      "artifactsBaseUrl"="https://raw.githubusercontent.com/elastic/azure-marketplace/7.2/src"
       "esVersion" = "7.1.1"
       "esClusterName" = "elasticsearch"
       "loadBalancerType" = "internal"
@@ -641,7 +641,7 @@ where `<name>` refers to the resource group you just created.
 5. Use our template directly from GitHub
 
   ```powershell
-  New-AzureRmResourceGroupDeployment -Name "<deployment name>" -ResourceGroupName "<name>" -TemplateUri "https://raw.githubusercontent.com/elastic/azure-marketplace/feature/247/src/mainTemplate.json" -TemplateParameterObject $clusterParameters
+  New-AzureRmResourceGroupDeployment -Name "<deployment name>" -ResourceGroupName "<name>" -TemplateUri "https://raw.githubusercontent.com/elastic/azure-marketplace/7.2/src/mainTemplate.json" -TemplateParameterObject $clusterParameters
   ```
 
 ## Targeting a specific template version

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Deploying through the Marketplace is great and easy way to get your feet wet for
 
 ![Example UI Flow](images/ui.gif)
 
-You can view the UI in developer mode by [clicking here](https://portal.azure.com/#blade/Microsoft_Azure_Compute/CreateMultiVmWizardBlade/internal_bladeCallId/anything/internal_bladeCallerParams/{"initialData":{},"providerConfig":{"createUiDefinition":"https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fazure-marketplace%2F7.2%2Fsrc%2FcreateUiDefinition.json"}}). If you feel something is cached improperly use [this client unoptimized link instead](https://portal.azure.com/?clientOptimizations=false#blade/Microsoft_Azure_Compute/CreateMultiVmWizardBlade/internal_bladeCallId/anything/internal_bladeCallerParams/{"initialData":{},"providerConfig":{"createUiDefinition":"https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fazure-marketplace%2F7.2%2Fsrc%2FcreateUiDefinition.json"}})
+You can view the UI in developer mode by [clicking here](https://portal.azure.com/#blade/Microsoft_Azure_Compute/CreateMultiVmWizardBlade/internal_bladeCallId/anything/internal_bladeCallerParams/{"initialData":{},"providerConfig":{"createUiDefinition":"https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fazure-marketplace%2Ffeature%2F247%2Fsrc%2FcreateUiDefinition.json"}}). If you feel something is cached improperly use [this client unoptimized link instead](https://portal.azure.com/?clientOptimizations=false#blade/Microsoft_Azure_Compute/CreateMultiVmWizardBlade/internal_bladeCallId/anything/internal_bladeCallerParams/{"initialData":{},"providerConfig":{"createUiDefinition":"https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fazure-marketplace%2Ffeature%2F247%2Fsrc%2FcreateUiDefinition.json"}})
 
 ## Reporting bugs
 
@@ -556,7 +556,7 @@ value defined in the template.
 
 ### Web based deploy
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fazure-marketplace%2F7.2%2Fsrc%2FmainTemplate.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fazure-marketplace%2Ffeature%2F247%2Fsrc%2FmainTemplate.json" target="_blank">
    <img alt="Deploy to Azure" src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 
@@ -590,7 +590,7 @@ supported by the last release. It's recommended to update to [Azure CLI 2.0](htt
 ```sh
 az group deployment create \
   --resource-group <name> \
-  --template-uri https://raw.githubusercontent.com/elastic/azure-marketplace/7.2/src/mainTemplate.json \
+  --template-uri https://raw.githubusercontent.com/elastic/azure-marketplace/feature/247/src/mainTemplate.json \
   --parameters @parameters/password.parameters.json
 ```
 
@@ -615,7 +615,7 @@ where `<name>` refers to the resource group you just created.
 
   ```powershell
   $clusterParameters = @{
-      "artifactsBaseUrl"="https://raw.githubusercontent.com/elastic/azure-marketplace/7.2/src"
+      "artifactsBaseUrl"="https://raw.githubusercontent.com/elastic/azure-marketplace/feature/247/src"
       "esVersion" = "7.1.1"
       "esClusterName" = "elasticsearch"
       "loadBalancerType" = "internal"
@@ -641,7 +641,7 @@ where `<name>` refers to the resource group you just created.
 5. Use our template directly from GitHub
 
   ```powershell
-  New-AzureRmResourceGroupDeployment -Name "<deployment name>" -ResourceGroupName "<name>" -TemplateUri "https://raw.githubusercontent.com/elastic/azure-marketplace/7.2/src/mainTemplate.json" -TemplateParameterObject $clusterParameters
+  New-AzureRmResourceGroupDeployment -Name "<deployment name>" -ResourceGroupName "<name>" -TemplateUri "https://raw.githubusercontent.com/elastic/azure-marketplace/feature/247/src/mainTemplate.json" -TemplateParameterObject $clusterParameters
   ```
 
 ## Targeting a specific template version

--- a/README.md
+++ b/README.md
@@ -410,13 +410,17 @@ value defined in the template.
   <tr><td colspan="4" style="font-size:120%"><strong>Logstash related settings</strong></td></tr>
 
   <tr><td>logstash</td><td>string</td>
-    <td>Either <code>Yes</code> or <code>No</code> to provision a machine with Logstash installed.
+    <td>Either <code>Yes</code> or <code>No</code> to provision Logstash VMs.
     </td><td><code>No</code></td></tr>
 
   <tr><td>vmSizeLogstash</td><td>string</td>
     <td>Azure VM size of the Logstash instance. See <a href="https://github.com/elastic/azure-marketplace/blob/master/build/allowedValues.json">this list for supported sizes</a>.
     <strong>Check that the size you select is <a href="https://azure.microsoft.com/en-au/regions/services/">available in the region you choose</a></strong>.
     </td><td><code>Standard_D1</code></td></tr>
+
+  <tr><td>vmLogstashCount</td><td>int</td>
+    <td>The number of Logstash instances
+    </td><td><code>1</code></td></tr>
 
   <tr><td>vmLogstashAcceleratedNetworking</td><td>string</td>
     <td>Whether to enable <a href="https://azure.microsoft.com/en-us/blog/maximize-your-vm-s-performance-with-accelerated-networking-now-generally-available-for-both-windows-and-linux/">accelerated networking</a> for Logstash, which enables single root I/O virtualization (SR-IOV) 

--- a/build/arm-tests/1d-0m-0c-ext-tls-klp.json
+++ b/build/arm-tests/1d-0m-0c-ext-tls-klp.json
@@ -1,5 +1,5 @@
 {
-  "description": "1 data node cluster with logstash",
+  "description": "1 data node cluster with 2 instances of logstash",
   "condition" : {
     "range": ">=6.3.0",
     "reason": "the use of xpack.monitoring.collection.enabled requires version to be 6.3.0+"
@@ -20,6 +20,7 @@
     "vmSizeKibana":{"value":"Standard_DS1_v2"},
     "logstash":{"value":"Yes"},
     "vmSizeLogstash":{"value":"Standard_DS1_v2"},
+    "vmLogstashCount":{"value":2},
     "logstashAdditionalPlugins":{"value":"logstash-input-heartbeat"},
     "logstashConf":{"value":"conf/logstash-tls.conf"},
     "vmSizeDataNodes":{"value":"Standard_DS1_v2"},

--- a/docs/azure-arm-template.asciidoc
+++ b/docs/azure-arm-template.asciidoc
@@ -909,7 +909,7 @@ Kibana communicates with Elasticsearch through the <<internal-load-balancer, int
 [[azure-arm-template-logstash]]
 === Logstash
 
-A single instance of Logstash can be deployed in addition to Elasticsearch, providing a pipeline for ingesting data into Elasticsearch.
+Multiple instances of Logstash can be deployed in addition to Elasticsearch, providing a pipeline for ingesting data into Elasticsearch.
 The version of Logstash deployed is always the same as the version of Elasticsearch, ensuring compatibility between products.
 
 The following parameters can be used to deploy Logstash, and control additional configuration
@@ -921,12 +921,8 @@ Whether to deploy Logstash in addition to Elasticsearch. A value of `Yes` will a
 The {vms}[Azure VM SKU] to use for Logstash. Different VM SKUs have different CPU, RAM,
 temporary storage space and network bandwidth. The Logstash VM always uses standard storage for the OS disk. The default value is `Standard_D1`.
 
-[NOTE]
---
-The template deploys only a single instance of Logstash. You should ensure that a VM SKU
-of sufficient size is chosen to be able to handle the expected amount of traffic. A larger VM
-SKU will generally be faster and have better bandwidth than a smaller VM SKU.
---
+`vmLogstashCount`::
+The number of Logstash VMs to deploy. Defaults to `1`.
 
 `vmLogstashAcceleratedNetworking`::
 Whether to enable {acceleratednetworking}[accelerated networking] for Logstash,

--- a/docs/azure-marketplace.asciidoc
+++ b/docs/azure-marketplace.asciidoc
@@ -152,9 +152,9 @@ the latter is used to connect to the Kibana VM via SSH.
 
 image:images/marketplace_step4_2.png[]
 
-When installing Logstash, a separate VM will be provisioned onto which Logstash
+When installing Logstash, separate VMs will be provisioned onto which Logstash
 will be deployed. A Logstash configuration file can be specified, as well as additional
-Logstash plugins to install.
+Logstash plugins to install. The Logstash VMs are placed in an Availability set.
 
 A jumpbox VM can optionally be deployed, which can be connected to via SSH in order
 to gain access to the Elasticsearch VMs.

--- a/docs/faqs.asciidoc
+++ b/docs/faqs.asciidoc
@@ -79,7 +79,7 @@ ssh <admin username>@<internal IP address or VM hostname>
 See the <<azure-arm-template-troubleshooting, troubleshooting section>> for more details.
 
 Does the Marketplace solution deploy Logstash?::
-The Marketplace solution can also deploy Logstash, although it does not do so by default.
-To also deploy an instance of Logstash, select `Yes` for `Install Logstash?` in the
+The Marketplace solution can also deploy multiple instances of Logstash, although it does not do so by default.
+To also deploy instances of Logstash, select `Yes` for `Install Logstash?` in the
 `Kibana & Logstash` section. You can also deploy additional plugins and provide a
 Logstash config file to use.

--- a/parameters/password.parameters.json
+++ b/parameters/password.parameters.json
@@ -1,5 +1,5 @@
 {
-  "artifactsBaseUrl":{"value":"https://raw.githubusercontent.com/elastic/azure-marketplace/7.2/src"},
+  "artifactsBaseUrl":{"value":"https://raw.githubusercontent.com/elastic/azure-marketplace/feature/247/src"},
   "esVersion":{"value":"6.7.0"},
   "esClusterName":{"value":"my-azure-cluster"},
   "loadBalancerType":{"value":"internal"},

--- a/parameters/password.parameters.json
+++ b/parameters/password.parameters.json
@@ -1,5 +1,5 @@
 {
-  "artifactsBaseUrl":{"value":"https://raw.githubusercontent.com/elastic/azure-marketplace/feature/247/src"},
+  "artifactsBaseUrl":{"value":"https://raw.githubusercontent.com/elastic/azure-marketplace/7.2/src"},
   "esVersion":{"value":"6.7.0"},
   "esClusterName":{"value":"my-azure-cluster"},
   "loadBalancerType":{"value":"internal"},

--- a/parameters/password.parameters.json
+++ b/parameters/password.parameters.json
@@ -28,6 +28,7 @@
   "kibanaAdditionalYaml": { "value":""},
   "logstash": { "value":"No"},
   "vmSizeLogstash": { "value":"Standard_D1"},
+  "vmLogstashCount": { "value":1},
   "vmLogstashAcceleratedNetworking":{"value":"Default"},
   "logstashHeapSize": { "value": 0 },
   "logstashConf": { "value": "" },

--- a/parameters/ssh.parameters.json
+++ b/parameters/ssh.parameters.json
@@ -1,5 +1,5 @@
 {
-  "artifactsBaseUrl":{"value":"https://raw.githubusercontent.com/elastic/azure-marketplace/7.2/src"},
+  "artifactsBaseUrl":{"value":"https://raw.githubusercontent.com/elastic/azure-marketplace/feature/247/src"},
   "esVersion":{"value":"6.7.0"},
   "esClusterName":{"value":"my-azure-cluster"},
   "loadBalancerType":{"value":"internal"},

--- a/parameters/ssh.parameters.json
+++ b/parameters/ssh.parameters.json
@@ -1,5 +1,5 @@
 {
-  "artifactsBaseUrl":{"value":"https://raw.githubusercontent.com/elastic/azure-marketplace/feature/247/src"},
+  "artifactsBaseUrl":{"value":"https://raw.githubusercontent.com/elastic/azure-marketplace/7.2/src"},
   "esVersion":{"value":"6.7.0"},
   "esClusterName":{"value":"my-azure-cluster"},
   "loadBalancerType":{"value":"internal"},

--- a/parameters/ssh.parameters.json
+++ b/parameters/ssh.parameters.json
@@ -28,6 +28,7 @@
   "kibanaAdditionalYaml": { "value":""},
   "logstash": { "value":"No"},
   "vmSizeLogstash": { "value":"Standard_D1"},
+  "vmLogstashCount": { "value":1},
   "vmLogstashAcceleratedNetworking":{"value":"Default"},
   "logstashHeapSize": { "value": 0 },
   "logstashConf": { "value": "" },

--- a/src/createUiDefinition.json
+++ b/src/createUiDefinition.json
@@ -1091,7 +1091,7 @@
                 "type": "Microsoft.Common.OptionsGroup",
                 "label": "Install Logstash?",
                 "defaultValue": "No",
-                "toolTip": "Yes, to provision a single Logstash instance.",
+                "toolTip": "Yes, to provision Logstash instances",
                 "constraints": {
                   "allowedValues": [
                     {
@@ -1106,10 +1106,62 @@
                 }
               },
               {
+                "name": "vmLogstashCount",
+                "type": "Microsoft.Common.DropDown",
+                "label": "Number of Logstash VMs",
+                "visible": "[equals(steps('externalAccessStep').logstashSection.logstash, 'Yes')]",
+                "defaultValue": "1",
+                "toolTip": "Specify the number of Logstash instances to deploy.",
+                "constraints": {
+                  "allowedValues": [
+                    {
+                      "label": "1",
+                      "value": 1
+                    },
+                    {
+                      "label": "2",
+                      "value": 2
+                    },
+                    {
+                      "label": "3",
+                      "value": 3
+                    },
+                    {
+                      "label": "4",
+                      "value": 4
+                    },
+                    {
+                      "label": "5",
+                      "value": 5
+                    },
+                    {
+                      "label": "6",
+                      "value": 6
+                    },
+                    {
+                      "label": "7",
+                      "value": 7
+                    },
+                    {
+                      "label": "8",
+                      "value": 8
+                    },
+                    {
+                      "label": "9",
+                      "value": 9
+                    },
+                    {
+                      "label": "10",
+                      "value": 10
+                    }
+                  ]
+                }
+              },
+              {
                 "name": "vmSizeLogstash",
                 "type": "Microsoft.Compute.SizeSelector",
                 "label": "Logstash VM size",
-                "toolTip": "Choose VM SKU, Standard D1, D2, D3",
+                "toolTip": "Choose VM SKU for Logstash",
                 "visible": "[equals(steps('externalAccessStep').logstashSection.logstash, 'Yes')]",
                 "recommendedSizes": [
                   "Standard_D1",
@@ -1245,7 +1297,7 @@
                   ]
                 },
                 "osPlatform": "Linux",
-                "count": "1"
+                "count": "[steps('externalAccessStep').logstashSection.vmLogstashCount]"
               },
               {
                 "name": "logstashConf",
@@ -1757,6 +1809,7 @@
       "kibanaAdditionalYaml": "",
       "logstash": "[steps('externalAccessStep').logstashSection.logstash]",
       "vmSizeLogstash": "[steps('externalAccessStep').logstashSection.vmSizeLogstash]",
+      "vmLogstashCount": "[steps('externalAccessStep').logstashSection.vmLogstashCount]",
       "vmLogstashAcceleratedNetworking": "Default",
       "logstashHeapSize": 0,
       "logstashConf": "[steps('externalAccessStep').logstashSection.logstashConf]",

--- a/src/machines/logstash-resources.json
+++ b/src/machines/logstash-resources.json
@@ -8,52 +8,10 @@
         "description": "Base uri of resources"
       }
     },
-    "location": {
-      "type": "string",
-      "metadata": {
-        "description": "Location where resources will be provisioned"
-      }
-    },
-    "namespace": {
-      "type": "string",
-      "metadata": {
-        "description": "The unique namespace for the Kibana VM"
-      }
-    },
-    "networkSettings": {
+    "vm": {
       "type": "object",
       "metadata": {
-        "description": "Network settings"
-      }
-    },
-    "credentials": {
-      "type": "secureObject",
-      "metadata": {
-        "description": "Credentials information block"
-      }
-    },
-    "osSettings": {
-      "type": "object",
-      "metadata": {
-        "description": "Platform and OS settings"
-      }
-    },
-    "vmSize": {
-      "type": "string",
-      "defaultValue": "Standard_D1",
-      "metadata": {
-        "description": "Size of the Logstash VM"
-      }
-    },
-    "acceleratedNetworking": {
-      "type": "string",
-      "defaultValue": "No",
-      "allowedValues": [
-        "Yes",
-        "No"
-      ],
-      "metadata": {
-        "description": "Whether to enable accelerated networking for Logstash, which enables single root I/O virtualization (SR-IOV) to a VM, greatly improving its networking performance. Valid only for specific VM SKUs"
+        "description": "vm configuration"
       }
     },
     "elasticTags": {
@@ -67,105 +25,60 @@
     }
   },
   "variables": {
-    "namespace": "[parameters('namespace')]",
-    "subnetId": "[resourceId(parameters('networkSettings').resourceGroup, 'Microsoft.Network/virtualNetworks/subnets', parameters('networkSettings').name, parameters('networkSettings').subnet.name)]",
-    "nicName": "[concat(variables('namespace'), '-nic')]",
-    "password_osProfile": {
-      "computername": "[parameters('namespace')]",
-      "adminUsername": "[parameters('credentials').adminUsername]",
-      "adminPassword": "[parameters('credentials').password]"
-    },
-    "sshPublicKey_osProfile": {
-      "computername": "[parameters('namespace')]",
-      "adminUsername": "[parameters('credentials').adminUsername]",
-      "linuxConfiguration": {
-        "disablePasswordAuthentication": "true",
-        "ssh": {
-          "publicKeys": [
-            {
-              "path": "[concat('/home/', parameters('credentials').adminUsername, '/.ssh/authorized_keys')]",
-              "keyData": "[parameters('credentials').sshPublicKey]"
-            }
-          ]
-      }
-      }
-    },
-    "osProfile": "[variables(concat(parameters('credentials').authenticationType, '_osProfile'))]"
+    "namespace": "[parameters('vm').namespace]"
   },
   "resources": [
     {
-      "apiVersion": "2017-10-01",
-      "type": "Microsoft.Network/networkInterfaces",
-      "name": "[variables('nicName')]",
-      "location": "[parameters('location')]",
+      "apiVersion": "2017-03-30",
+      "type": "Microsoft.Compute/availabilitySets",
+      "name": "[concat(variables('namespace'), 'av-set')]",
+      "location": "[parameters('vm').shared.location]",
       "tags": {
         "provider": "[toUpper(parameters('elasticTags').provider)]"
       },
-      "dependsOn": [
-      ],
       "properties": {
-        "primary": true,
-        "enableAcceleratedNetworking": "[equals(parameters('acceleratedNetworking'), 'Yes')]",
-        "ipConfigurations": [
-          {
-            "name": "ipconfig1",
-            "properties": {
-              "privateIPAllocationMethod": "Dynamic",
-              "subnet": {
-                "id": "[variables('subnetId')]"
-              }
-            }
-          }
-        ]
+        "platformUpdateDomainCount": 20,
+        "platformFaultDomainCount": "[parameters('vm').platformFaultDomainCount]"
+      },
+      "sku": {
+        "name": "Aligned"
       }
     },
     {
-      "apiVersion": "2017-12-01",
-      "type": "Microsoft.Compute/virtualMachines",
-      "name": "[parameters('namespace')]",
-      "location": "[parameters('location')]",
-      "tags": {
-        "provider": "[toUpper(parameters('elasticTags').provider)]"
-      },
+      "name": "[concat(variables('namespace'), copyindex(), '-vm-creation')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2017-05-10",
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+        "[concat('Microsoft.Compute/availabilitySets/', variables('namespace'), 'av-set')]"
       ],
-      "properties": {
-        "hardwareProfile": {
-          "vmSize": "[parameters('vmSize')]"
-        },
-        "osProfile": "[variables('osProfile')]",
-        "storageProfile": {
-          "imageReference": "[parameters('osSettings').imageReference]",
-          "osDisk": {
-            "name": "[concat(variables('namespace'), '-osdisk')]",
-            "managedDisk": {
-              "storageAccountType": "Standard_LRS"
-            },
-            "caching": "ReadWrite",
-            "createOption": "FromImage"
-          }
-        },
-        "networkProfile": {
-          "networkInterfaces": [
-            {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
-            }
-          ]
-        }
+      "copy": {
+        "name": "[concat(variables('namespace'),'vm-creation-loop')]",
+        "count": "[parameters('vm').count]"
       },
-      "resources": [
-        {
-          "type": "Microsoft.Compute/virtualMachines/extensions",
-          "name": "[concat(variables('namespace'), '/script')]",
-          "apiVersion": "2017-12-01",
-          "location": "[parameters('location')]",
-          "dependsOn": [
-            "[concat('Microsoft.Compute/virtualMachines/', parameters('namespace'))]"
-          ],
-          "properties": "[parameters('osSettings').extensionSettings.logstash]"
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(parameters('templateBaseUrl'), 'partials/vm.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "templateBaseUrl": {
+            "value": "[parameters('templateBaseUrl')]"
+          },
+          "vm": {
+            "value": "[parameters('vm')]"
+          },
+          "availabilitySet": {
+            "value": "[concat(variables('namespace'), 'av-set')]"
+          },
+          "index": {
+            "value": "[copyindex()]"
+          },
+          "elasticTags": {
+            "value": "[parameters('elasticTags')]"
+          }
         }
-      ]
+      }
     }
   ],
   "outputs": {}

--- a/src/mainTemplate.json
+++ b/src/mainTemplate.json
@@ -505,6 +505,14 @@
         "description": "Size of the Logstash nodes"
       }
     },
+    "vmLogstashCount": {
+      "type": "int",
+      "defaultValue": 1,
+      "minValue": 1,
+      "metadata": {
+        "description": "The number of Logstash VMs to deploy"
+      }
+    },
     "vmLogstashAcceleratedNetworking": {
       "type": "string",
       "defaultValue": "Default",
@@ -1918,6 +1926,7 @@
       "kibanaHttps": "[variables('kibanaHttps')]",
       "kibanaYaml": "[parameters('kibanaAdditionalYaml')]",
       "vmSizeLogstash": "[parameters('vmSizeLogstash')]",
+      "vmLogstashCount": "[parameters('vmLogstashCount')]",
       "vmLogstashAcceleratedNetworking": "[parameters('vmLogstashAcceleratedNetworking')]",
       "logstash": "[parameters('logstash')]",
       "logstashHeapSize": "[parameters('logstashHeapSize')]",

--- a/src/mainTemplate.json
+++ b/src/mainTemplate.json
@@ -4,7 +4,7 @@
   "parameters": {
     "artifactsBaseUrl": {
       "type": "string",
-      "defaultValue": "https://raw.githubusercontent.com/elastic/azure-marketplace/feature/247/src",
+      "defaultValue": "https://raw.githubusercontent.com/elastic/azure-marketplace/7.2/src",
       "metadata": {
         "artifactsBaseUrl": "Base URL of the Elastic template gallery package"
       }

--- a/src/mainTemplate.json
+++ b/src/mainTemplate.json
@@ -4,7 +4,7 @@
   "parameters": {
     "artifactsBaseUrl": {
       "type": "string",
-      "defaultValue": "https://raw.githubusercontent.com/elastic/azure-marketplace/7.2/src",
+      "defaultValue": "https://raw.githubusercontent.com/elastic/azure-marketplace/feature/247/src",
       "metadata": {
         "artifactsBaseUrl": "Base URL of the Elastic template gallery package"
       }

--- a/src/partials/node-resources.json
+++ b/src/partials/node-resources.json
@@ -178,7 +178,6 @@
               "size": "[parameters('topologySettings').vmSizeMasterNodes]",
               "storageAccountType": "Standard_LRS",
               "count": 3,
-              "useBackendPools": "No",
               "backendPools": [],
               "imageReference": "[parameters('osSettings').imageReference]",
               "platformFaultDomainCount": "[variables('platformFaultDomainCount')]",
@@ -215,7 +214,6 @@
               "size": "[parameters('topologySettings').vmSizeClientNodes]",
               "count": "[parameters('topologySettings').vmClientNodeCount]",
               "storageAccountType": "Standard_LRS",
-              "useBackendPools": "Yes",
               "backendPools": "[parameters('topologySettings').loadBalancerBackEndPools]",
               "imageReference": "[parameters('osSettings').imageReference]",
               "platformFaultDomainCount": "[variables('platformFaultDomainCount')]",
@@ -251,7 +249,6 @@
               "size": "[parameters('topologySettings').vmSizeDataNodes]",
               "storageAccountType": "[parameters('topologySettings').vmDataNodeStorageAccountType]",
               "count": "[parameters('topologySettings').vmDataNodeCount]",
-              "useBackendPools": "Yes",
               "backendPools": "[parameters('topologySettings').dataLoadBalancerBackEndPools]",
               "imageReference": "[parameters('osSettings').imageReference]",
               "platformFaultDomainCount": "[variables('platformFaultDomainCount')]",
@@ -361,26 +358,19 @@
           "templateBaseUrl": {
             "value": "[parameters('templateBaseUrl')]"
           },
-          "credentials": {
-            "value": "[parameters('commonVmSettings').credentials]"
-          },
-          "location": {
-            "value": "[parameters('commonVmSettings').location]"
-          },
-          "namespace": {
-            "value": "[concat(parameters('commonVmSettings').namespacePrefix, 'logstash')]"
-          },
-          "networkSettings": {
-            "value": "[parameters('networkSettings')]"
-          },
-          "osSettings": {
-            "value": "[parameters('osSettings')]"
-          },
-          "vmSize": {
-            "value": "[parameters('topologySettings').vmSizeLogstash]"
-          },
-          "acceleratedNetworking": {
-            "value": "[if(equals(parameters('topologySettings').vmLogstashAcceleratedNetworking, 'Default'), if(contains(variables('vmAcceleratedNetworking'), parameters('topologySettings').vmSizeLogstash), 'Yes', 'No'), parameters('topologySettings').vmLogstashAcceleratedNetworking)]"
+          "vm": {
+            "value": {
+              "shared": "[parameters('commonVmSettings')]",
+              "namespace": "[concat(parameters('commonVmSettings').namespacePrefix, 'logstash-')]",
+              "installScript": "[parameters('osSettings').extensionSettings.logstash]",
+              "size": "[parameters('topologySettings').vmSizeLogstash]",
+              "storageAccountType": "Standard_LRS",
+              "count": "[parameters('topologySettings').vmLogstashCount]",
+              "backendPools": [],
+              "imageReference": "[parameters('osSettings').imageReference]",
+              "platformFaultDomainCount": "[variables('platformFaultDomainCount')]",
+              "acceleratedNetworking": "[if(equals(parameters('topologySettings').vmLogstashAcceleratedNetworking, 'Default'), if(contains(variables('vmAcceleratedNetworking'), parameters('topologySettings').vmSizeLogstash), 'Yes', 'No'), parameters('topologySettings').vmLogstashAcceleratedNetworking)]"
+            }
           },
           "elasticTags": {
             "value": "[parameters('elasticTags')]"

--- a/src/partials/vm.json
+++ b/src/partials/vm.json
@@ -23,7 +23,7 @@
     "availabilitySet": {
       "type": "string",
       "metadata": {
-        "description": "Base uri of resources"
+        "description": "The name of the availability set"
       }
     },
     "dataDisks": {


### PR DESCRIPTION
This PR allows multiple instances of Logstash to be deployed. Similar to data, client and master nodes, multiple Logstash VMs are deployed in an Availability set, with fault and update domains.

The naming of logstash resources follow the convention for multiple counts of a resource i.e. logstash-0, logstash-1, etc. prefixed with the vmHostNamePrefix.

Closes #247