### PR TITLE
[DOCS] Specifies the title of the getting started section in Azure Marketplace and ARM template

### DIFF
--- a/docs/azure-arm-template.asciidoc
+++ b/docs/azure-arm-template.asciidoc
@@ -52,7 +52,7 @@ group, or as a full deployment, which will replace all resources within a resour
 group.
 
 [[azure-arm-template-getting-started]]
-=== Getting started
+=== Getting started with the ARM template
 
 The best way to work with Elastic's ARM template is using one of the official Azure
 command line interface (CLI) tools:

--- a/docs/azure-marketplace.asciidoc
+++ b/docs/azure-marketplace.asciidoc
@@ -29,7 +29,7 @@ started experience. After the trial license expires, Elasticsearch operates
 in a degraded mode.
 
 [[azure-marketplace-getting-started]]
-=== Getting started
+=== Getting started with the Azure Marketplace
 
 Navigate to the {marketplace}[Azure Marketplace] offering, and click the "Get it Now"
 button:


### PR DESCRIPTION
This PR amends the getting started section titles in the Azure Marketplace related docs. The amended titles specify the subject of the getting started section – in line with the efforts of the documentation team to make getting started guides and tutorials more exact.