### PR TITLE
Update 7.6 version to latest patch, 7.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,7 +638,7 @@ where `<name>` refers to the resource group you just created.
 
   ```powershell
   $branch = "master"
-  $esVersion = "7.6.0"
+  $esVersion = "7.6.2"
 
   $clusterParameters = @{
       "_artifactsLocation" = "https://raw.githubusercontent.com/elastic/azure-marketplace/$branch/src/"
@@ -677,16 +677,16 @@ the `_artifactsLocation` parameter of the template to point to a specific tagged
 
 **Targeting a specific template version is recommended for repeatable production deployments.**
 
-For example, to target the [`7.6.0` tag release with PowerShell](https://github.com/elastic/azure-marketplace/tree/7.6.0)
+For example, to target the [`7.6.2` tag release with PowerShell](https://github.com/elastic/azure-marketplace/tree/7.6.2)
 
 ```powershell
-$templateVersion = "7.6.0"
+$templateVersion = "7.6.2"
 $_artifactsLocation = "https://raw.githubusercontent.com/elastic/azure-marketplace/$templateVersion/src/"
 
 # minimum parameters required to deploy
 $clusterParameters = @{
   "_artifactsLocation" = $_artifactsLocation
-  "esVersion" = "7.6.0"
+  "esVersion" = "7.6.2"
   "adminUsername" = "russ"
   "adminPassword" = "Password1234"
   "securityBootstrapPassword" = "Password1234"

--- a/build/allowedValues.json
+++ b/build/allowedValues.json
@@ -11,7 +11,7 @@
     "7.3.2",
     "7.4.2",
     "7.5.2",
-    "7.6.0"
+    "7.6.2"
   ],
   "numberOfDataNodes" : 50,
   "numberOfClientNodes" : 20,

--- a/docs/azure-arm-template.asciidoc
+++ b/docs/azure-arm-template.asciidoc
@@ -2,7 +2,7 @@
 :portal: https://portal.azure.com
 :github: https://github.com/elastic/azure-marketplace
 :current: 7.6
-:version: 7.6.0
+:version: 7.6.2
 :register: https://register.elastic.co
 :elasticguide: https://www.elastic.co/guide/en/elasticsearch
 :elasticdocs: {elasticguide}/reference/{current}

--- a/parameters/password.parameters.json
+++ b/parameters/password.parameters.json
@@ -1,7 +1,7 @@
 {
   "_artifactsLocation":{"value":"https://raw.githubusercontent.com/elastic/azure-marketplace/master/src/"},
   "_artifactsLocationSasToken":{"value":""},
-  "esVersion":{"value":"7.6.0"},
+  "esVersion":{"value":"7.6.2"},
   "esClusterName":{"value":"my-azure-cluster"},
   "loadBalancerType":{"value":"internal"},
   "loadBalancerInternalSku":{"value":"Basic"},

--- a/parameters/ssh.parameters.json
+++ b/parameters/ssh.parameters.json
@@ -1,7 +1,7 @@
 {
   "_artifactsLocation":{"value":"https://raw.githubusercontent.com/elastic/azure-marketplace/master/src/"},
   "_artifactsLocationSasToken":{"value":""},
-  "esVersion":{"value":"7.6.0"},
+  "esVersion":{"value":"7.6.2"},
   "esClusterName":{"value":"my-azure-cluster"},
   "loadBalancerType":{"value":"internal"},
   "loadBalancerInternalSku":{"value":"Basic"},

--- a/src/createUiDefinition.json
+++ b/src/createUiDefinition.json
@@ -54,7 +54,7 @@
             "name": "esVersion",
             "type": "Microsoft.Common.DropDown",
             "label": "Elasticsearch version",
-            "defaultValue": "v7.6.0",
+            "defaultValue": "v7.6.2",
             "toolTip": "Choose a version of Elasticsearch.",
             "constraints": {
               "allowedValues": [
@@ -103,8 +103,8 @@
                   "value": "7.5.2"
                 },
                 {
-                  "label": "v7.6.0",
-                  "value": "7.6.0"
+                  "label": "v7.6.2",
+                  "value": "7.6.2"
                 }
               ]
             }

--- a/src/mainTemplate.json
+++ b/src/mainTemplate.json
@@ -28,7 +28,7 @@
     },
     "esVersion": {
       "type": "string",
-      "defaultValue": "7.6.0",
+      "defaultValue": "7.6.2",
       "allowedValues": [
         "6.4.3",
         "6.5.4",
@@ -41,7 +41,7 @@
         "7.3.2",
         "7.4.2",
         "7.5.2",
-        "7.6.0"
+        "7.6.2"
       ],
       "metadata": {
         "description": "Elastic Stack version to install"


### PR DESCRIPTION
Hi all!

With these update I'm trying to update to latest 7.6 patch version, 7.6.2. We are deploying ElasticSearch 7.6.0 using this ARM template and found some nasty bugs solved in the latest patch version. 

I don't know to where I should point the links with "npm run links". Should I point them to my cloned repo? To the original one but the branch? If you let me know the correct approach I can update the PR adding this change.

Let me know if missed something 🙈 