### PR TITLE
[DOCS] Fixes Stack Overview links

### DIFF
--- a/docs/azure-arm-template.asciidoc
+++ b/docs/azure-arm-template.asciidoc
@@ -6,11 +6,11 @@
 :register: https://register.elastic.co
 :elasticguide: https://www.elastic.co/guide/en/elasticsearch
 :elasticdocs: {elasticguide}/reference/{current}
+:kibana-ref: https://www.elastic.co/guide/en/kibana/{current}
 :elasticstack: https://www.elastic.co/products/stack
-:stackdocs: https://www.elastic.co/guide/en/elastic-stack-overview/{current}
 :xpackenabled: {elasticdocs}/security-settings.html#general-security-settings
-:bootstrappassword: : {stackdocs}/built-in-users.html#bootstrap-elastic-passwords
-:licenseexpiration: {stackdocs}/license-expiration.html
+:bootstrappassword: : {elasticdocs}/built-in-users.html#bootstrap-elastic-passwords
+:licenseexpiration: {kibana-ref}/managing-licenses.html
 :microsoftdocs: https://docs.microsoft.com
 :azuredocs: https://azure.microsoft.com
 :azurecli: {microsoftdocs}/cli/azure/?view=azure-cli-latest

--- a/docs/trial-license-warning.asciidoc
+++ b/docs/trial-license-warning.asciidoc
@@ -1,7 +1,7 @@
 :current: 7.7
 :register: https://register.elastic.co
 :elasticdocs: https://www.elastic.co/guide/en/elasticsearch/reference/{current}
-:licenseexpiration: {stackdocs}/license-expiration.html
+:licenseexpiration: {kibana-ref}/managing-licenses.html#license-expiration
 
 [WARNING]
 --


### PR DESCRIPTION
This PR fixes out-dated links to the Stack Overview book, which is no longer used.

Related to https://github.com/elastic/docs/pull/1870