### PR TITLE
[DOCS] Fixes more X-Pack links

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ value defined in the template.
     </td><td><code>""</code></td></tr>
 
   <tr><td>securityBootstrapPassword</td><td>securestring</td>
-    <td>Security password for 6.x <a href="https://www.elastic.co/guide/en/x-pack/current/setting-up-authentication.html#bootstrap-elastic-passwords"><code>bootstrap.password</code> key</a> that is added to the keystore. If no value is supplied, a 13 character password
+    <td>Security password for 6.x <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/built-in-users.html#bootstrap-elastic-passwords"><code>bootstrap.password</code> key</a> that is added to the keystore. If no value is supplied, a 13 character password
     will be generated using the ARM template <code>uniqueString()</code> function. The bootstrap password is used to seed the built-in
     users. Used only in 6.0.0+
     </td><td><code>""</code></td></tr>

--- a/docs/azure-arm-template.asciidoc
+++ b/docs/azure-arm-template.asciidoc
@@ -195,7 +195,7 @@ running version {version}
 * Kibana {version}.
 * The cluster has three master-eligible data nodes, each with a single 1024GB attached managed disk.
 * The cluster will have a trial license applied, providing access to Elastic Stack Platinum features for 30 days
-* Security feature is enabled, and the {elasticdocs}/built-in-roles.html[built-in users] `elastic`, `kibana`,
+* Security feature is enabled, and the {elasticdocs}/built-in-users.html[built-in users] `elastic`, `kibana`,
 `logstash_system`, `apm_system` and `remote_monitoring_user` are configured.
 
 The ARM template accepts _many_ {github}#parameters[parameters], many of which are optional. When a value is not supplied for a parameter, a default value defined within the

--- a/docs/azure-arm-template.asciidoc
+++ b/docs/azure-arm-template.asciidoc
@@ -195,7 +195,7 @@ running version {version}
 * Kibana {version}.
 * The cluster has three master-eligible data nodes, each with a single 1024GB attached managed disk.
 * The cluster will have a trial license applied, providing access to Elastic Stack Platinum features for 30 days
-* Security feature is enabled, and the {xpackdocs}/built-in-roles.html[built-in users] `elastic`, `kibana`,
+* Security feature is enabled, and the {elasticdocs}/built-in-roles.html[built-in users] `elastic`, `kibana`,
 `logstash_system`, `apm_system` and `remote_monitoring_user` are configured.
 
 The ARM template accepts _many_ {github}#parameters[parameters], many of which are optional. When a value is not supplied for a parameter, a default value defined within the

--- a/docs/azure-marketplace.asciidoc
+++ b/docs/azure-marketplace.asciidoc
@@ -3,7 +3,6 @@
 :github: https://github.com/elastic/azure-marketplace
 :elasticdocs: https://www.elastic.co/guide/en/elasticsearch/reference/current
 :elasticstack: https://www.elastic.co/products/stack
-:xpackdocs: https://www.elastic.co/guide/en/x-pack/current
 :microsoftdocs: https://docs.microsoft.com
 :azurecli: {microsoftdocs}/cli/azure/?view=azure-cli-latest
 :azurepowershell: {microsoftdocs}/powershell/azure/overview?view=azurermps-6.4.0
@@ -172,7 +171,7 @@ to Elasticsearch from outside of Azure over port 9200.
 An Elasticsearch cluster deployed through the Azure Marketplace is always deployed
 with a 30 day trial license that enables all of {subscriptions}[the platinum features of the Elastic Stack]. 
 Security features allow Basic Authentication configuration for the cluster, setting up six
-{xpackdocs}/setting-up-authentication.html[built-in user accounts]
+{elasticdocs}/built-in-users.html[built-in user accounts]
 
 . The `elastic` user, a built-in superuser account
 . The `kibana` user, a built-in account that Kibana uses to connect and


### PR DESCRIPTION
Related to https://github.com/elastic/azure-marketplace/pull/348

This PR cleans up more out-dated links to X-Pack documentation.