### PR TITLE
Escape double quotes in passwords and use kibana keystore

### DIFF
--- a/docs/azure-arm-template.asciidoc
+++ b/docs/azure-arm-template.asciidoc
@@ -195,7 +195,7 @@ running version {version}
 * Kibana {version}.
 * The cluster has three master-eligible data nodes, each with a single 1024GB attached managed disk.
 * The cluster will have a trial license applied, providing access to Elastic Stack Platinum features for 30 days
-* Security feature is enabled, and the {elasticdocs}/built-in-users.html[built-in users] `elastic`, `kibana`,
+* Security feature is enabled, and the {elasticdocs}/built-in-users.html[built-in users] `elastic`, `kibana[_system]`,
 `logstash_system`, `apm_system` and `remote_monitoring_user` are configured.
 
 The ARM template accepts _many_ {github}#parameters[parameters], many of which are optional. When a value is not supplied for a parameter, a default value defined within the
@@ -1067,8 +1067,8 @@ Keep this password somewhere safe; You never know when you may need it!
 --
 
 `securityKibanaPassword`::
-Security password for the `kibana` built-in user account. This is the account that
-Kibana uses to communicate with Elasticsearch. Must be greater
+Security password for the `kibana` (`kibana_system` in 7.8.0+) built-in user account. 
+This is the account that Kibana uses to communicate with Elasticsearch. Must be greater
 than six characters in length.
 
 `securityLogstashPassword`::

--- a/docs/azure-marketplace.asciidoc
+++ b/docs/azure-marketplace.asciidoc
@@ -187,7 +187,7 @@ Security features allow Basic Authentication configuration for the cluster, sett
 {elasticdocs}/built-in-users.html[built-in user accounts]
 
 . The `elastic` user, a built-in superuser account
-. The `kibana` user, a built-in account that Kibana uses to connect and
+. The `kibana` user (`kibana_system` in 7.8.0+), a built-in account that Kibana uses to connect and
 communicate with Elasticsearch
 . The `logstash_system` user, a built-in account that can be used by Logstash
 when storing monitoring information in Elasticsearch.

--- a/src/createUiDefinition.json
+++ b/src/createUiDefinition.json
@@ -1397,10 +1397,10 @@
                 "name": "securityKibanaPassword",
                 "type": "Microsoft.Common.PasswordBox",
                 "label": {
-                  "password": "'kibana' built-in user password",
+                  "password": "'kibana'/'kibana_system' built-in user password",
                   "confirmPassword": "Confirm password"
                 },
-                "toolTip": "Password for the built-in 'kibana' user. This is a built-in account that Kibana uses to communicate with Elasticsearch",
+                "toolTip": "Password for the built-in 'kibana' user (`kibana_system` in 7.8.0+). This is a built-in account that Kibana uses to communicate with Elasticsearch",
                 "constraints": {
                   "required": true,
                   "regex": "^.{12,}",

--- a/src/scripts/elasticsearch-install.sh
+++ b/src/scripts/elasticsearch-install.sh
@@ -562,14 +562,19 @@ apply_security_settings()
       fi
       log "[apply_security_settings] updated built-in elastic superuser password"
 
-      #update builtin `kibana` account
+      #update builtin `kibana`/`kibana_system` account
       local KIBANA_JSON=$(printf '{"password":"%s"}\n' $USER_KIBANA_PWD)
-      echo $KIBANA_JSON | curl_ignore_409 -XPUT -u "elastic:$USER_ADMIN_PWD" "$XPACK_USER_ENDPOINT/kibana/_password" -d @-
+      local KIBANA_USER="kibana"
+      if dpkg --compare-versions "$ES_VERSION" "ge" "7.8.0"; then
+        KIBANA_USER="kibana_system"
+      fi 
+
+      echo $KIBANA_JSON | curl_ignore_409 -XPUT -u "elastic:$USER_ADMIN_PWD" "$XPACK_USER_ENDPOINT/$KIBANA_USER/_password" -d @-
       if [[ $? != 0 ]];  then
-        log "[apply_security_settings] could not update the built-in kibana user"
+        log "[apply_security_settings] could not update the built-in $KIBANA_USER user"
         exit 10
       fi
-      log "[apply_security_settings] updated built-in kibana user password"
+      log "[apply_security_settings] updated built-in $KIBANA_USER user password"
 
       #update builtin `logstash_system` account
       local LOGSTASH_JSON=$(printf '{"password":"%s"}\n' $USER_LOGSTASH_PWD)
@@ -580,37 +585,32 @@ apply_security_settings()
       fi
       log "[apply_security_settings] updated built-in logstash_system user password"
 
-      #update builtin `beats_system` account for Elasticsearch 6.3.0+
-      if dpkg --compare-versions "$ES_VERSION" "ge" "6.3.0"; then
-        local BEATS_JSON=$(printf '{"password":"%s"}\n' $USER_BEATS_PWD)
-        echo $BEATS_JSON | curl_ignore_409 -XPUT -u "elastic:$USER_ADMIN_PWD" "$XPACK_USER_ENDPOINT/beats_system/_password" -d @-
-        if [[ $? != 0 ]];  then
-          log "[apply_security_settings] could not update the built-in beats_system user"
-          exit 10
-        fi
-        log "[apply_security_settings] updated built-in beats_system user password"
+      #update builtin `beats_system` account
+      local BEATS_JSON=$(printf '{"password":"%s"}\n' $USER_BEATS_PWD)
+      echo $BEATS_JSON | curl_ignore_409 -XPUT -u "elastic:$USER_ADMIN_PWD" "$XPACK_USER_ENDPOINT/beats_system/_password" -d @-
+      if [[ $? != 0 ]];  then
+        log "[apply_security_settings] could not update the built-in beats_system user"
+        exit 10
       fi
+      log "[apply_security_settings] updated built-in beats_system user password"
 
-      
-      if dpkg --compare-versions "$ES_VERSION" "ge" "6.5.0"; then
-        #update builtin `apm_system` account for Elasticsearch 6.5.0+
-        local APM_JSON=$(printf '{"password":"%s"}\n' $USER_APM_PWD)
-        echo $APM_JSON | curl_ignore_409 -XPUT -u "elastic:$USER_ADMIN_PWD" "$XPACK_USER_ENDPOINT/apm_system/_password" -d @-
-        if [[ $? != 0 ]];  then
-          log "[apply_security_settings] could not update the built-in apm_system user"
-          exit 10
-        fi
-        log "[apply_security_settings] updated built-in apm_system user password"
-      
-        #update builtin `remote_monitoring_user` account for Elasticsearch 6.5.0+
-        local REMOTE_MONITORING_JSON=$(printf '{"password":"%s"}\n' $USER_REMOTE_MONITORING_PWD)
-        echo $REMOTE_MONITORING_JSON | curl_ignore_409 -XPUT -u "elastic:$USER_ADMIN_PWD" "$XPACK_USER_ENDPOINT/remote_monitoring_user/_password" -d @-
-        if [[ $? != 0 ]];  then
-          log "[apply_security_settings] could not update the built-in remote_monitoring_user user"
-          exit 10
-        fi
-        log "[apply_security_settings] updated built-in remote_monitoring_user user password"     
-      fi   
+      #update builtin `apm_system` account
+      local APM_JSON=$(printf '{"password":"%s"}\n' $USER_APM_PWD)
+      echo $APM_JSON | curl_ignore_409 -XPUT -u "elastic:$USER_ADMIN_PWD" "$XPACK_USER_ENDPOINT/apm_system/_password" -d @-
+      if [[ $? != 0 ]];  then
+        log "[apply_security_settings] could not update the built-in apm_system user"
+        exit 10
+      fi
+      log "[apply_security_settings] updated built-in apm_system user password"
+    
+      #update builtin `remote_monitoring_user`
+      local REMOTE_MONITORING_JSON=$(printf '{"password":"%s"}\n' $USER_REMOTE_MONITORING_PWD)
+      echo $REMOTE_MONITORING_JSON | curl_ignore_409 -XPUT -u "elastic:$USER_ADMIN_PWD" "$XPACK_USER_ENDPOINT/remote_monitoring_user/_password" -d @-
+      if [[ $? != 0 ]];  then
+        log "[apply_security_settings] could not update the built-in remote_monitoring_user user"
+        exit 10
+      fi
+      log "[apply_security_settings] updated built-in remote_monitoring_user user password" 
     fi
 }
 

--- a/src/scripts/elasticsearch-install.sh
+++ b/src/scripts/elasticsearch-install.sh
@@ -530,6 +530,11 @@ curl_ignore_409 () {
     fi
 }
 
+escape_pwd() 
+{
+  echo $1 | sed 's/"/\\"/g'
+}
+
 apply_security_settings()
 {
     # if the node is up, check that the elastic user exists in the .security index if
@@ -550,7 +555,8 @@ apply_security_settings()
       local XPACK_ROLE_ENDPOINT="$PROTOCOL://localhost:9200/$XPACK_SECURITY_PATH/role"
 
       #update builtin `elastic` account.
-      local ADMIN_JSON=$(printf '{"password":"%s"}\n' $USER_ADMIN_PWD)
+      local ESCAPED_USER_ADMIN_PWD=$(escape_pwd $USER_ADMIN_PWD)
+      local ADMIN_JSON=$(printf '{"password":"%s"}\n' $ESCAPED_USER_ADMIN_PWD)
       echo $ADMIN_JSON | curl_ignore_409 -XPUT -u "elastic:$SEED_PASSWORD" "$XPACK_USER_ENDPOINT/elastic/_password" -d @-
       if [[ $? != 0 ]]; then
         #Make sure another deploy did not already change the elastic password
@@ -563,7 +569,8 @@ apply_security_settings()
       log "[apply_security_settings] updated built-in elastic superuser password"
 
       #update builtin `kibana`/`kibana_system` account
-      local KIBANA_JSON=$(printf '{"password":"%s"}\n' $USER_KIBANA_PWD)
+      local ESCAPED_USER_KIBANA_PWD=$(escape_pwd $USER_KIBANA_PWD)
+      local KIBANA_JSON=$(printf '{"password":"%s"}\n' $ESCAPED_USER_KIBANA_PWD)
       local KIBANA_USER="kibana"
       if dpkg --compare-versions "$ES_VERSION" "ge" "7.8.0"; then
         KIBANA_USER="kibana_system"
@@ -577,7 +584,8 @@ apply_security_settings()
       log "[apply_security_settings] updated built-in $KIBANA_USER user password"
 
       #update builtin `logstash_system` account
-      local LOGSTASH_JSON=$(printf '{"password":"%s"}\n' $USER_LOGSTASH_PWD)
+      local ESCAPED_USER_LOGSTASH_PWD=$(escape_pwd $USER_LOGSTASH_PWD)
+      local LOGSTASH_JSON=$(printf '{"password":"%s"}\n' $ESCAPED_USER_LOGSTASH_PWD)
       echo $LOGSTASH_JSON | curl_ignore_409 -XPUT -u "elastic:$USER_ADMIN_PWD" "$XPACK_USER_ENDPOINT/logstash_system/_password" -d @-
       if [[ $? != 0 ]];  then
         log "[apply_security_settings] could not update the built-in logstash_system user"
@@ -586,7 +594,8 @@ apply_security_settings()
       log "[apply_security_settings] updated built-in logstash_system user password"
 
       #update builtin `beats_system` account
-      local BEATS_JSON=$(printf '{"password":"%s"}\n' $USER_BEATS_PWD)
+      local ESCAPED_USER_BEATS_PWD=$(escape_pwd $USER_BEATS_PWD)
+      local BEATS_JSON=$(printf '{"password":"%s"}\n' $ESCAPED_USER_BEATS_PWD)
       echo $BEATS_JSON | curl_ignore_409 -XPUT -u "elastic:$USER_ADMIN_PWD" "$XPACK_USER_ENDPOINT/beats_system/_password" -d @-
       if [[ $? != 0 ]];  then
         log "[apply_security_settings] could not update the built-in beats_system user"
@@ -595,7 +604,8 @@ apply_security_settings()
       log "[apply_security_settings] updated built-in beats_system user password"
 
       #update builtin `apm_system` account
-      local APM_JSON=$(printf '{"password":"%s"}\n' $USER_APM_PWD)
+      local ESCAPED_USER_APM_PWD=$(escape_pwd $USER_APM_PWD)
+      local APM_JSON=$(printf '{"password":"%s"}\n' $ESCAPED_USER_APM_PWD)
       echo $APM_JSON | curl_ignore_409 -XPUT -u "elastic:$USER_ADMIN_PWD" "$XPACK_USER_ENDPOINT/apm_system/_password" -d @-
       if [[ $? != 0 ]];  then
         log "[apply_security_settings] could not update the built-in apm_system user"
@@ -604,7 +614,8 @@ apply_security_settings()
       log "[apply_security_settings] updated built-in apm_system user password"
     
       #update builtin `remote_monitoring_user`
-      local REMOTE_MONITORING_JSON=$(printf '{"password":"%s"}\n' $USER_REMOTE_MONITORING_PWD)
+      local ESCAPED_USER_REMOTE_MONITORING_PWD=$(escape_pwd $USER_REMOTE_MONITORING_PWD)
+      local REMOTE_MONITORING_JSON=$(printf '{"password":"%s"}\n' $ESCAPED_USER_REMOTE_MONITORING_PWD)
       echo $REMOTE_MONITORING_JSON | curl_ignore_409 -XPUT -u "elastic:$USER_ADMIN_PWD" "$XPACK_USER_ENDPOINT/remote_monitoring_user/_password" -d @-
       if [[ $? != 0 ]];  then
         log "[apply_security_settings] could not update the built-in remote_monitoring_user user"

--- a/src/scripts/elasticsearch-install.sh
+++ b/src/scripts/elasticsearch-install.sh
@@ -513,10 +513,6 @@ wait_for_started()
 # since upserts of roles users CAN throw 409 conflicts we ignore these for now
 # opened an issue on x-pack repos to handle this more gracefully later
 curl_ignore_409 () {
-    _curl_with_error_code "$@" | sed '$d'
-}
-
-_curl_with_error_code () {
     local curl_error_code http_code
     exec 17>&1
     http_code=$(curl -H 'Content-Type: application/json' --write-out '\n%{http_code}\n' "$@" $CURL_SWITCH | tee /dev/fd/17 | tail -n 1)

--- a/src/scripts/kibana-install.sh
+++ b/src/scripts/kibana-install.sh
@@ -238,7 +238,11 @@ configure_kibana_yaml()
     local ENCRYPTION_KEY
 
     if [[ ${INSTALL_XPACK} -ne 0 || ${BASIC_SECURITY} -ne 0 ]]; then
-      echo "elasticsearch.username: kibana" >> $KIBANA_CONF
+      local KIBANA_USER="kibana"
+      if dpkg --compare-versions "$KIBANA_VERSION" "ge" "7.8.0"; then
+        KIBANA_USER="kibana_system"
+      fi 
+      echo "elasticsearch.username: $KIBANA_USER" >> $KIBANA_CONF
 
       # store credentials in the keystore
       create_keystore_if_not_exists


### PR DESCRIPTION
This PR fixes a bug when a user supplied password for a built-in user account contains one or more double quotes. Since the password is inserted into a JSON string that forms part of a JSON object for the update password API request body, any double quotes need to be escaped within the password to form valid JSON.

When a request to update a built-in user password fails, the deployment should fail, but this was not happening because the status code of the function performing the operation was not propagated correctly. This is also addressed.

In addition to this bug fix, this PR also 

- creates and uses the kibana keystore to store credentials for Kibana
- uses `kibana_system` for the built-in Kibana user in 7.8.0+