### PR TITLE
Add notice recommending Elastic Cloud offering in Azure

### DIFF
--- a/docs/azure-marketplace.asciidoc
+++ b/docs/azure-marketplace.asciidoc
@@ -17,6 +17,8 @@
 [[azure-marketplace]]
 == Azure Marketplace solution
 
+IMPORTANT: As a prefered solution, we recommend using our newer link:https://azuremarketplace.microsoft.com/en-us/marketplace/apps/elastic.ec-azure-pp?exp=ubp8&tab=Overview[Elastic Cloud (Elasticsearch Service)] offering in the Azure Marketplace. To learn more, refer to the link:https://www.elastic.co/guide/en/cloud/current/ec-azure-marketplace-native.html[Native Azure integration documentation].
+
 The Azure Marketplace solution offering is a preconfigured
 template to deploy an Elasticsearch cluster, Kibana and Logstash to Azure. It's available
 on {marketplace}[Microsoft's Azure Marketplace], making it easy to find and
@@ -28,21 +30,10 @@ all {subscriptions}[the Platinum features of the Elastic Stack], to provide the 
 started experience. After the trial license expires, Elasticsearch operates
 in a degraded mode.
 
-[IMPORTANT]
---
-
-The Marketplace solution template is a great starting place to try out the Elastic Stack on
-Azure. In the long run, it's recommended to deploy the Elastic Stack
-<<azure-arm-template, using the ARM template from our GitHub repository directly>>. 
-Doing so allows for targeting a specific template release for 
-<<azure-arm-template-repeatable-deployments, repeatable deployments>>, in addition to
-allowing <<azure-arm-template-scaling-nodes, scaling up the number of nodes under certain conditions>>, 
-a process that the Marketplace solution template is not designed for.
-
---
-
 [[azure-marketplace-getting-started]]
 === Getting started with the Azure Marketplace
+
+IMPORTANT: As a prefered solution, we recommend using our newer link:https://azuremarketplace.microsoft.com/en-us/marketplace/apps/elastic.ec-azure-pp?exp=ubp8&tab=Overview[Elastic Cloud (Elasticsearch Service)] offering in the Azure Marketplace. To learn more, refer to the link:https://www.elastic.co/guide/en/cloud/current/ec-azure-marketplace-native.html[Native Azure integration documentation].
 
 Navigate to the {marketplace}[Azure Marketplace] offering, and click the "Get it Now"
 button:

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -16,6 +16,8 @@
 [[azure-marketplace-arm-template-introduction]]
 == Introduction
 
+IMPORTANT: As a prefered solution, we recommend using our newer link:https://azuremarketplace.microsoft.com/en-us/marketplace/apps/elastic.ec-azure-pp?exp=ubp8&tab=Overview[Elastic Cloud (Elasticsearch Service)] offering in the Azure Marketplace. To learn more, refer to the link:https://www.elastic.co/guide/en/cloud/current/ec-azure-marketplace-native.html[Native Azure integration documentation].
+
 The {marketplace}[Microsoft Azure Marketplace] solution is a preconfigured
 template to deploy an Elasticsearch cluster, Kibana, and Logstash to Azure.
 


### PR DESCRIPTION
This adds a notice on a few pages in the documentation referring customers to the Azure Marketplace [Elastic Cloud offering](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/elastic.ec-azure-pp?exp=ubp8&tab=Overview).

![Screenshot 2023-03-02 at 6 23 26 PM](https://user-images.githubusercontent.com/41695641/222587507-3b5b962f-c20c-4dca-8307-e27a84d164c1.png)

@russcam  We had a request for this from product marketing in order to help ensure that customers are able to find the newer offering. I hope you don't mind.